### PR TITLE
Changes to reduce documentation clutter and add LICENSE details

### DIFF
--- a/concrete/dense.go
+++ b/concrete/dense.go
@@ -1,3 +1,7 @@
+// Copyright ©2014 The gonum Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
 package concrete
 
 import (

--- a/concrete/densegraph_test.go
+++ b/concrete/densegraph_test.go
@@ -1,3 +1,7 @@
+// Copyright ©2014 The gonum Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
 package concrete_test
 
 import (

--- a/concrete/gonumgraph.go
+++ b/concrete/gonumgraph.go
@@ -1,3 +1,7 @@
+// Copyright ©2014 The gonum Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
 package concrete
 
 import (

--- a/concrete/gonumgraph_test.go
+++ b/concrete/gonumgraph_test.go
@@ -1,3 +1,7 @@
+// Copyright ©2014 The gonum Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
 package concrete_test
 
 import (

--- a/concrete/tilegraph.go
+++ b/concrete/tilegraph.go
@@ -1,3 +1,7 @@
+// Copyright ©2014 The gonum Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
 package concrete
 
 import (

--- a/concrete/tilegraph_test.go
+++ b/concrete/tilegraph_test.go
@@ -1,3 +1,7 @@
+// Copyright ©2014 The gonum Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
 package concrete_test
 
 import (

--- a/doc.go
+++ b/doc.go
@@ -1,3 +1,7 @@
+// Copyright ©2014 The gonum Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
 /*
 Package graph implements functions and interfaces to deal with formal discrete graphs. It aims to
 be first and foremost flexible, with speed as a strong second priority.

--- a/graph.go
+++ b/graph.go
@@ -1,3 +1,7 @@
+// Copyright ©2014 The gonum Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
 package graph
 
 // All a node needs to do is identify itself. This allows the user to pass in nodes more

--- a/search/floydw_test.go
+++ b/search/floydw_test.go
@@ -1,3 +1,7 @@
+// Copyright ©2014 The gonum Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
 package search_test
 
 import (

--- a/search/floydwarshall.go
+++ b/search/floydwarshall.go
@@ -1,3 +1,7 @@
+// Copyright ©2014 The gonum Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
 package search
 
 import (

--- a/search/graphSearch.go
+++ b/search/graphSearch.go
@@ -1,3 +1,7 @@
+// Copyright ©2014 The gonum Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
 package search
 
 import (

--- a/search/internals.go
+++ b/search/internals.go
@@ -1,3 +1,7 @@
+// Copyright ©2014 The gonum Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
 package search
 
 import (

--- a/search/search_test.go
+++ b/search/search_test.go
@@ -1,3 +1,7 @@
+// Copyright ©2014 The gonum Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
 package search_test
 
 import (

--- a/set/disjoint.go
+++ b/set/disjoint.go
@@ -1,3 +1,7 @@
+// Copyright ©2014 The gonum Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
 package set
 
 // A disjoint set is a collection of non-overlapping sets. That is, for any two sets in the

--- a/set/disjointset_test.go
+++ b/set/disjointset_test.go
@@ -1,3 +1,7 @@
+// Copyright ©2014 The gonum Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
 package set
 
 import (

--- a/set/set.go
+++ b/set/set.go
@@ -1,3 +1,7 @@
+// Copyright ©2014 The gonum Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
 package set
 
 import ()

--- a/set/set_test.go
+++ b/set/set_test.go
@@ -1,3 +1,7 @@
+// Copyright ©2014 The gonum Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
 package set_test
 
 import (

--- a/xifo/deque.go
+++ b/xifo/deque.go
@@ -1,3 +1,7 @@
+// Copyright ©2014 The gonum Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
 package xifo
 
 import ()

--- a/xifo/xifo_test.go
+++ b/xifo/xifo_test.go
@@ -1,3 +1,7 @@
+// Copyright ©2014 The gonum Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
 package xifo_test
 
 import (


### PR DESCRIPTION
I would like to see all these merged since they reflect the std lib approach to naming and label use, but if you are averse to them I can cope with that.
