### PR TITLE
Tile cleanup

### DIFF
--- a/internal/tilegraph.go
+++ b/internal/tilegraph.go
@@ -2,14 +2,16 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-package concrete
+package internal
 
 import (
 	"bytes"
 	"errors"
+	"math"
 	"strings"
 
 	"github.com/gonum/graph"
+	"github.com/gonum/graph/concrete"
 )
 
 const (
@@ -19,6 +21,8 @@ const (
 	goalChar    = 'g'
 	pathChar    = '\u2665'
 )
+
+var inf = math.Inf(1)
 
 type TileGraph struct {
 	tiles            []bool
@@ -40,8 +44,8 @@ func NewTileGraph(dimX, dimY int, isPassable bool) *TileGraph {
 	}
 }
 
-func GenerateTileGraph(template string) (*TileGraph, error) {
-	rows := strings.Split(strings.TrimSpace(template), "\n")
+func NewTileGraphFrom(text string) (*TileGraph, error) {
+	rows := strings.Split(text, "\n")
 
 	tiles := make([]bool, 0)
 
@@ -164,7 +168,7 @@ func (g *TileGraph) CoordsToNode(row, col int) graph.Node {
 	if id == -1 {
 		return nil
 	}
-	return Node(id)
+	return concrete.Node(id)
 }
 
 func (g *TileGraph) Neighbors(n graph.Node) []graph.Node {
@@ -194,7 +198,7 @@ func (g *TileGraph) EdgeBetween(n, neigh graph.Node) graph.Edge {
 	r1, c1 := g.IDToCoords(n.ID())
 	r2, c2 := g.IDToCoords(neigh.ID())
 	if (c1 == c2 && (r2 == r1+1 || r2 == r1-1)) || (r1 == r2 && (c2 == c1+1 || c2 == c1-1)) {
-		return Edge{n, neigh}
+		return concrete.Edge{n, neigh}
 	}
 
 	return nil
@@ -216,8 +220,8 @@ func (g *TileGraph) EdgeList() []graph.Edge {
 			continue
 		}
 
-		for _, succ := range g.Neighbors(Node(id)) {
-			edges = append(edges, Edge{Node(id), succ})
+		for _, succ := range g.Neighbors(concrete.Node(id)) {
+			edges = append(edges, concrete.Edge{concrete.Node(id), succ})
 		}
 	}
 
@@ -231,7 +235,7 @@ func (g *TileGraph) NodeList() []graph.Node {
 			continue
 		}
 
-		nodes = append(nodes, Node(id))
+		nodes = append(nodes, concrete.Node(id))
 	}
 
 	return nodes

--- a/internal/tilegraph_test.go
+++ b/internal/tilegraph_test.go
@@ -2,19 +2,20 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-package concrete_test
+package internal_test
 
 import (
 	"testing"
 
 	"github.com/gonum/graph"
 	"github.com/gonum/graph/concrete"
+	"github.com/gonum/graph/internal"
 )
 
-var _ graph.Graph = (*concrete.TileGraph)(nil)
+var _ graph.Graph = (*internal.TileGraph)(nil)
 
 func TestTileGraph(t *testing.T) {
-	tg := concrete.NewTileGraph(4, 4, false)
+	tg := internal.NewTileGraph(4, 4, false)
 
 	if tg == nil || tg.String() != "▀▀▀▀\n▀▀▀▀\n▀▀▀▀\n▀▀▀▀" {
 		t.Fatal("Tile graph not generated correctly")
@@ -55,7 +56,7 @@ func TestTileGraph(t *testing.T) {
 		t.Fatal("Passability set incorrectly")
 	}
 
-	if tg2, err := concrete.GenerateTileGraph("▀  ▀\n▀▀ ▀\n▀▀ ▀\n▀▀ ▀"); err != nil {
+	if tg2, err := internal.NewTileGraphFrom("▀  ▀\n▀▀ ▀\n▀▀ ▀\n▀▀ ▀"); err != nil {
 		t.Error("Tile graph errored on interpreting valid template string\n▀  ▀\n▀▀ ▀\n▀▀ ▀\n▀▀ ▀")
 	} else if tg2.String() != "▀  ▀\n▀▀ ▀\n▀▀ ▀\n▀▀ ▀" {
 		t.Error("Tile graph failed to generate properly with input string\n▀  ▀\n▀▀ ▀\n▀▀ ▀\n▀▀ ▀")
@@ -104,5 +105,4 @@ func TestTileGraph(t *testing.T) {
 	if tg.Degree(concrete.Node(0)) != 0 {
 		t.Error("Degree returns incorrect number for impassable tile (0,0)")
 	}
-
 }

--- a/search/search_test.go
+++ b/search/search_test.go
@@ -18,9 +18,14 @@ import (
 )
 
 func TestSimpleAStar(t *testing.T) {
-	tg, err := concrete.GenerateTileGraph("▀  ▀\n▀▀ ▀\n▀▀ ▀\n▀▀ ▀")
+	tg, err := internal.NewTileGraphFrom("" +
+		"▀  ▀\n" +
+		"▀▀ ▀\n" +
+		"▀▀ ▀\n" +
+		"▀▀ ▀",
+	)
 	if err != nil {
-		t.Fatal("Couldn't generate tilegraph")
+		t.Fatalf("Couldn't generate tilegraph: %v", err)
 	}
 
 	path, cost, _ := search.AStar(concrete.Node(1), concrete.Node(14), tg, nil, nil)
@@ -44,7 +49,7 @@ func TestSimpleAStar(t *testing.T) {
 }
 
 func TestBiggerAStar(t *testing.T) {
-	tg := concrete.NewTileGraph(3, 3, true)
+	tg := internal.NewTileGraph(3, 3, true)
 
 	path, cost, _ := search.AStar(concrete.Node(0), concrete.Node(8), tg, nil, nil)
 
@@ -52,7 +57,7 @@ func TestBiggerAStar(t *testing.T) {
 		t.Error("Non-optimal or impossible path found for 3x3 grid")
 	}
 
-	tg = concrete.NewTileGraph(1000, 1000, true)
+	tg = internal.NewTileGraph(1000, 1000, true)
 	path, cost, _ = search.AStar(concrete.Node(0), concrete.Node(999*1000+999), tg, nil, nil)
 	if !search.IsPath(path, tg) || cost != 1998 {
 		t.Error("Non-optimal or impossible path found for 100x100 grid; cost:", cost, "path:\n"+tg.PathString(path))
@@ -60,7 +65,7 @@ func TestBiggerAStar(t *testing.T) {
 }
 
 func TestObstructedAStar(t *testing.T) {
-	tg := concrete.NewTileGraph(10, 10, true)
+	tg := internal.NewTileGraph(10, 10, true)
 
 	// Creates a partial "wall" down the middle row with a gap down the left side
 	tg.SetPassability(4, 1, false)
@@ -104,7 +109,7 @@ func TestObstructedAStar(t *testing.T) {
 }
 
 func TestNoPathAStar(t *testing.T) {
-	tg := concrete.NewTileGraph(5, 5, true)
+	tg := internal.NewTileGraph(5, 5, true)
 
 	// Creates a "wall" down the middle row
 	tg.SetPassability(2, 0, false)


### PR DESCRIPTION
This is a small set of changes that allows TileGraph to interact with encoding cleanly and reduces the string operation load.

In the long run it would be nice to know where this kind of graph is going to be used. I think that marshaling as pretty runes is probably a wrong thing to do - a Render function would be more appropriate to handle that.