### PR TITLE
Defer adding new nodes to graph

### DIFF
--- a/concrete/mutablegr.go
+++ b/concrete/mutablegr.go
@@ -67,13 +67,11 @@ func NewGraph() *Graph {
 func (g *Graph) NewNode() graph.Node {
 	if g.maxID != maxInt {
 		g.maxID++
-		g.AddNode(Node(g.maxID))
 		return Node(g.maxID)
 	}
 
 	// Implicitly checks if len(g.freeMap) == 0
 	for id := range g.freeMap {
-		g.AddNode(Node(id))
 		return Node(id)
 	}
 
@@ -84,7 +82,6 @@ func (g *Graph) NewNode() graph.Node {
 
 	for i := 0; i < maxInt; i++ {
 		if _, ok := g.nodeMap[i]; !ok {
-			g.AddNode(Node(i))
 			return Node(i)
 		}
 	}

--- a/concrete/mutablegr_test.go
+++ b/concrete/mutablegr_test.go
@@ -33,6 +33,10 @@ func TestMaxID(t *testing.T) {
 	g.RemoveNode(concrete.Node(2))
 	delete(nodes, concrete.Node(2))
 	n := g.NewNode()
+	g.AddNode(n)
+	if !g.NodeExists(n) {
+		t.Error("added node does not exist in graph")
+	}
 	if _, exists := nodes[n]; exists {
 		t.Errorf("Created already existing node id: %v", n.ID())
 	}

--- a/concrete/mutdir.go
+++ b/concrete/mutdir.go
@@ -37,13 +37,11 @@ func NewDirectedGraph() *DirectedGraph {
 func (g *DirectedGraph) NewNode() graph.Node {
 	if g.maxID != maxInt {
 		g.maxID++
-		g.AddNode(Node(g.maxID))
 		return Node(g.maxID)
 	}
 
 	// Implicitly checks if len(g.freeMap) == 0
 	for id := range g.freeMap {
-		g.AddNode(Node(id))
 		return Node(id)
 	}
 
@@ -54,7 +52,6 @@ func (g *DirectedGraph) NewNode() graph.Node {
 
 	for i := 0; i < maxInt; i++ {
 		if _, ok := g.nodeMap[i]; !ok {
-			g.AddNode(Node(i))
 			return Node(i)
 		}
 	}

--- a/graph.go
+++ b/graph.go
@@ -139,8 +139,7 @@ type HeuristicCoster interface {
 // itself. That said, any function that takes Mutable[x], the destination mutable should
 // always be a different graph than the source.
 type Mutable interface {
-	// NewNode adds a node with an arbitrary ID and returns the new, unique ID
-	// used.
+	// NewNode returns a node with a unique arbitrary ID.
 	NewNode() Node
 
 	// Adds a node to the graph. If this is called multiple times for the same ID, the newer node

--- a/search/graph_search.go
+++ b/search/graph_search.go
@@ -249,6 +249,7 @@ func Johnson(g graph.Graph, cost graph.CostFunc) (nodePaths map[int]map[int][]gr
 
 	/* Step 1: Dummy node with 0 cost edge weights to every other node*/
 	dummyNode := dummyGraph.NewNode()
+	dummyGraph.AddNode(dummyNode)
 	for _, node := range g.NodeList() {
 		dummyGraph.AddDirectedEdge(concrete.Edge{dummyNode, node}, 0)
 	}


### PR DESCRIPTION
This allows the ID of the node to be used in place of the returned node,
or the returned node to be placed in a graph.Node embedded field prior
to adding the wrapping struct.

@btracey @Jragonmiris @gonum/developers PTAL