### PR TITLE
graph/traverse: new package - basic traversal primitives

### DIFF
--- a/traverse/traverse.go
+++ b/traverse/traverse.go
@@ -1,0 +1,219 @@
+// Copyright ©2015 The gonum Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// Package traverse provides basic graph traversal primitives.
+package traverse
+
+import "github.com/gonum/graph"
+
+// BreadthFirst implements stateful breadth-first graph traversal.
+type BreadthFirst struct {
+	EdgeFilter func(graph.Edge) bool
+	Visit      func(u, v graph.Node)
+	queue      nodeQueue
+	visited    intSet
+}
+
+// Walk performs a breadth-first traversal of the graph g starting from the given node,
+// depending on the the EdgeFilter field and the until parameter if they are non-nil. The
+// traversal follows edges for which EdgeFilter(edge) is true and returns the first node
+// for which until(node, depth) is true. During the traversal, if the Visit field is
+// non-nil, it is called with the nodes joined by each followed edge.
+func (b *BreadthFirst) Walk(g graph.Graph, from graph.Node, until func(n graph.Node, d int) bool) graph.Node {
+	var neighbors func(graph.Node) []graph.Node
+	switch g := g.(type) {
+	case graph.DirectedGraph:
+		neighbors = g.Successors
+	default:
+		neighbors = g.Neighbors
+	}
+
+	if b.visited == nil {
+		b.visited = make(intSet)
+	}
+	b.queue.enqueue(from)
+	b.visited.add(from.ID())
+
+	var (
+		depth     int
+		children  int
+		untilNext = 1
+	)
+	for b.queue.len() > 0 {
+		t := b.queue.dequeue()
+		if until != nil && until(t, depth) {
+			return t
+		}
+		for _, n := range neighbors(t) {
+			if b.EdgeFilter != nil && !b.EdgeFilter(g.EdgeBetween(t, n)) {
+				continue
+			}
+			if b.visited.has(n.ID()) {
+				continue
+			}
+			if b.Visit != nil {
+				b.Visit(t, n)
+			}
+			b.visited.add(n.ID())
+			children++
+			b.queue.enqueue(n)
+		}
+		if untilNext--; untilNext == 0 {
+			depth++
+			untilNext = children
+			children = 0
+		}
+	}
+
+	return nil
+}
+
+// Visited returned whether the node n was visited during a traverse.
+func (b *BreadthFirst) Visited(n graph.Node) bool {
+	_, ok := b.visited[n.ID()]
+	return ok
+}
+
+// Reset resets the state of the traverser for reuse.
+func (b *BreadthFirst) Reset() {
+	b.queue.head = 0
+	b.queue.data = b.queue.data[:0]
+	b.visited = nil
+}
+
+// DepthFirst implements stateful depth-first graph traversal.
+type DepthFirst struct {
+	EdgeFilter func(graph.Edge) bool
+	Visit      func(u, v graph.Node)
+	stack      nodeStack
+	visited    intSet
+}
+
+// Walk performs a depth-first traversal of the graph g starting from the given node,
+// depending on the the EdgeFilter field and the until parameter if they are non-nil. The
+// traversal follows edges for which EdgeFilter(edge) is true and returns the first node
+// for which until(node) is true. During the traversal, if the Visit field is non-nil, it
+// is called with the nodes joined by each followed edge.
+func (d *DepthFirst) Walk(g graph.Graph, from graph.Node, until func(graph.Node) bool) graph.Node {
+	var neighbors func(graph.Node) []graph.Node
+	switch g := g.(type) {
+	case graph.DirectedGraph:
+		neighbors = g.Successors
+	default:
+		neighbors = g.Neighbors
+	}
+
+	if d.visited == nil {
+		d.visited = make(intSet)
+	}
+	d.stack.push(from)
+	d.visited.add(from.ID())
+
+	for d.stack.len() > 0 {
+		t := d.stack.pop()
+		if until != nil && until(t) {
+			return t
+		}
+		for _, n := range neighbors(t) {
+			if d.EdgeFilter != nil && !d.EdgeFilter(g.EdgeBetween(t, n)) {
+				continue
+			}
+			if d.visited.has(n.ID()) {
+				continue
+			}
+			if d.Visit != nil {
+				d.Visit(t, n)
+			}
+			d.visited.add(n.ID())
+			d.stack.push(n)
+		}
+	}
+
+	return nil
+}
+
+// Visited returned whether the node n was visited during a traverse.
+func (d *DepthFirst) Visited(n graph.Node) bool {
+	_, ok := d.visited[n.ID()]
+	return ok
+}
+
+// Reset resets the state of the traverser for reuse.
+func (d *DepthFirst) Reset() {
+	d.stack = d.stack[:0]
+	d.visited = nil
+}
+
+// nodeStack implements a LIFO stack.
+type nodeStack []graph.Node
+
+func (s *nodeStack) len() int { return len(*s) }
+func (s *nodeStack) pop() graph.Node {
+	v := *s
+	v, n := v[:len(v)-1], v[len(v)-1]
+	*s = v
+	return n
+}
+func (s *nodeStack) push(n graph.Node) { *s = append(*s, n) }
+
+// nodeQueue implements a FIFO queue.
+type nodeQueue struct {
+	head int
+	data []graph.Node
+}
+
+func (q *nodeQueue) len() int { return len(q.data) - q.head }
+func (q *nodeQueue) enqueue(n graph.Node) {
+	if len(q.data) == cap(q.data) && q.head > 0 {
+		l := q.len()
+		copy(q.data, q.data[q.head:])
+		q.head = 0
+		q.data = append(q.data[:l], n)
+	} else {
+		q.data = append(q.data, n)
+	}
+}
+func (q *nodeQueue) dequeue() graph.Node {
+	if q.len() == 0 {
+		panic("queue: empty queue")
+	}
+
+	var n graph.Node
+	n, q.data[q.head] = q.data[q.head], nil
+	q.head++
+
+	if q.len() == 0 {
+		q.head = 0
+		q.data = q.data[:0]
+	}
+
+	return n
+}
+
+// A set is a set of integer identifiers.
+type intSet map[int]struct{}
+
+// The simple accessor methods for Set are provided to allow ease of
+// implementation change should the need arise.
+
+// add inserts an element into the set.
+func (s intSet) add(e int) {
+	s[e] = struct{}{}
+}
+
+// has reports the existence of the element in the set.
+func (s intSet) has(e int) bool {
+	_, ok := s[e]
+	return ok
+}
+
+// remove deletes the specified element from the set.
+func (s intSet) remove(e int) {
+	delete(s, e)
+}
+
+// count reports the number of elements stored in the set.
+func (s intSet) count() int {
+	return len(s)
+}

--- a/traverse/traverse_test.go
+++ b/traverse/traverse_test.go
@@ -1,0 +1,390 @@
+// Copyright ©2015 The gonum Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package traverse_test
+
+import (
+	"reflect"
+	"sort"
+	"testing"
+
+	"github.com/gonum/graph"
+	"github.com/gonum/graph/concrete"
+	"github.com/gonum/graph/traverse"
+)
+
+var breadthFirstTests = []struct {
+	g     []set
+	from  graph.Node
+	edge  func(graph.Edge) bool
+	until func(graph.Node, int) bool
+	final map[graph.Node]bool
+	want  [][]int
+}{
+	{
+		g: []set{
+			0: linksTo(1, 4),
+			1: linksTo(2, 4),
+			2: linksTo(3),
+			3: linksTo(4, 5),
+			4: nil,
+			5: nil,
+		},
+		from:  concrete.Node(1),
+		final: map[graph.Node]bool{nil: true},
+		want: [][]int{
+			{1},
+			{0, 2, 4},
+			{3},
+			{5},
+		},
+	},
+	{
+		g: []set{
+			0: linksTo(1, 4),
+			1: linksTo(2, 4),
+			2: linksTo(3),
+			3: linksTo(4, 5),
+			4: nil,
+			5: nil,
+		},
+		edge: func(e graph.Edge) bool {
+			// Do not traverse an edge between 3 and 5.
+			return (e.Head().ID() != 3 || e.Tail().ID() != 5) && (e.Head().ID() != 5 || e.Tail().ID() != 3)
+		},
+		from:  concrete.Node(1),
+		final: map[graph.Node]bool{nil: true},
+		want: [][]int{
+			{1},
+			{0, 2, 4},
+			{3},
+		},
+	},
+	{
+		g: []set{
+			0: linksTo(1, 4),
+			1: linksTo(2, 4),
+			2: linksTo(3),
+			3: linksTo(4, 5),
+			4: nil,
+			5: nil,
+		},
+		from:  concrete.Node(1),
+		until: func(n graph.Node, _ int) bool { return n == concrete.Node(3) },
+		final: map[graph.Node]bool{concrete.Node(3): true},
+		want: [][]int{
+			{1},
+			{0, 2, 4},
+		},
+	},
+	{
+		g: []set{
+			0: nil,
+
+			1: linksTo(2, 3),
+			2: linksTo(4),
+			3: linksTo(4),
+			4: linksTo(5),
+			5: nil,
+
+			6:  linksTo(7, 8, 14),
+			7:  linksTo(8, 11, 12, 14),
+			8:  linksTo(14),
+			9:  linksTo(11),
+			10: linksTo(11),
+			11: linksTo(12),
+			12: linksTo(18),
+			13: linksTo(14, 15),
+			14: linksTo(15, 17),
+			15: linksTo(16, 17),
+			16: nil,
+			17: linksTo(18, 19, 20),
+			18: linksTo(19, 20),
+			19: linksTo(20),
+			20: nil,
+		},
+		from:  concrete.Node(13),
+		final: map[graph.Node]bool{nil: true},
+		want: [][]int{
+			{13},
+			{14, 15},
+			{6, 7, 8, 16, 17},
+			{11, 12, 18, 19, 20},
+			{9, 10},
+		},
+	},
+	{
+		g: []set{
+			0: nil,
+
+			1: linksTo(2, 3),
+			2: linksTo(4),
+			3: linksTo(4),
+			4: linksTo(5),
+			5: nil,
+
+			6:  linksTo(7, 8, 14),
+			7:  linksTo(8, 11, 12, 14),
+			8:  linksTo(14),
+			9:  linksTo(11),
+			10: linksTo(11),
+			11: linksTo(12),
+			12: linksTo(18),
+			13: linksTo(14, 15),
+			14: linksTo(15, 17),
+			15: linksTo(16, 17),
+			16: nil,
+			17: linksTo(18, 19, 20),
+			18: linksTo(19, 20),
+			19: linksTo(20),
+			20: nil,
+		},
+		from:  concrete.Node(13),
+		until: func(_ graph.Node, d int) bool { return d > 2 },
+		final: map[graph.Node]bool{
+			concrete.Node(11): true,
+			concrete.Node(12): true,
+			concrete.Node(18): true,
+			concrete.Node(19): true,
+			concrete.Node(20): true,
+		},
+		want: [][]int{
+			{13},
+			{14, 15},
+			{6, 7, 8, 16, 17},
+		},
+	},
+}
+
+func TestBreadthFirst(t *testing.T) {
+	for i, test := range breadthFirstTests {
+		g := concrete.NewGraph()
+		for u, e := range test.g {
+			if !g.NodeExists(concrete.Node(u)) {
+				g.AddNode(concrete.Node(u))
+			}
+			for v := range e {
+				if !g.NodeExists(concrete.Node(v)) {
+					g.AddNode(concrete.Node(v))
+				}
+				g.AddUndirectedEdge(concrete.Edge{H: concrete.Node(u), T: concrete.Node(v)}, 0)
+			}
+		}
+		w := traverse.BreadthFirst{
+			EdgeFilter: test.edge,
+		}
+		var got [][]int
+		final := w.Walk(g, test.from, func(n graph.Node, d int) bool {
+			if test.until != nil && test.until(n, d) {
+				return true
+			}
+			if d >= len(got) {
+				got = append(got, []int(nil))
+			}
+			got[d] = append(got[d], n.ID())
+			return false
+		})
+		if !test.final[final] {
+			t.Errorf("unexepected final node for test %d:\ngot:  %v\nwant: %v", i, final, test.final)
+		}
+		for _, l := range got {
+			sort.Ints(l)
+		}
+		if !reflect.DeepEqual(got, test.want) {
+			t.Errorf("unexepected BFS level structure for test %d:\ngot:  %v\nwant: %v", i, got, test.want)
+		}
+	}
+}
+
+var depthFirstTests = []struct {
+	g     []set
+	from  graph.Node
+	edge  func(graph.Edge) bool
+	until func(graph.Node) bool
+	final map[graph.Node]bool
+	want  []int
+}{
+	{
+		g: []set{
+			0: linksTo(1, 4),
+			1: linksTo(2, 4),
+			2: linksTo(3),
+			3: linksTo(4, 5),
+			4: nil,
+			5: nil,
+		},
+		from:  concrete.Node(1),
+		final: map[graph.Node]bool{nil: true},
+		want:  []int{0, 1, 2, 3, 4, 5},
+	},
+	{
+		g: []set{
+			0: linksTo(1, 4),
+			1: linksTo(2, 4),
+			2: linksTo(3),
+			3: linksTo(4, 5),
+			4: nil,
+			5: nil,
+		},
+		edge: func(e graph.Edge) bool {
+			// Do not traverse an edge between 3 and 5.
+			return (e.Head().ID() != 3 || e.Tail().ID() != 5) && (e.Head().ID() != 5 || e.Tail().ID() != 3)
+		},
+		from:  concrete.Node(1),
+		final: map[graph.Node]bool{nil: true},
+		want:  []int{0, 1, 2, 3, 4},
+	},
+	{
+		g: []set{
+			0: linksTo(1, 4),
+			1: linksTo(2, 4),
+			2: linksTo(3),
+			3: linksTo(4, 5),
+			4: nil,
+			5: nil,
+		},
+		from:  concrete.Node(1),
+		until: func(n graph.Node) bool { return n == concrete.Node(3) },
+		final: map[graph.Node]bool{concrete.Node(3): true},
+	},
+	{
+		g: []set{
+			0: nil,
+
+			1: linksTo(2, 3),
+			2: linksTo(4),
+			3: linksTo(4),
+			4: linksTo(5),
+			5: nil,
+
+			6:  linksTo(7, 8, 14),
+			7:  linksTo(8, 11, 12, 14),
+			8:  linksTo(14),
+			9:  linksTo(11),
+			10: linksTo(11),
+			11: linksTo(12),
+			12: linksTo(18),
+			13: linksTo(14, 15),
+			14: linksTo(15, 17),
+			15: linksTo(16, 17),
+			16: nil,
+			17: linksTo(18, 19, 20),
+			18: linksTo(19, 20),
+			19: linksTo(20),
+			20: nil,
+		},
+		from:  concrete.Node(0),
+		final: map[graph.Node]bool{nil: true},
+		want:  []int{0},
+	},
+	{
+		g: []set{
+			0: nil,
+
+			1: linksTo(2, 3),
+			2: linksTo(4),
+			3: linksTo(4),
+			4: linksTo(5),
+			5: nil,
+
+			6:  linksTo(7, 8, 14),
+			7:  linksTo(8, 11, 12, 14),
+			8:  linksTo(14),
+			9:  linksTo(11),
+			10: linksTo(11),
+			11: linksTo(12),
+			12: linksTo(18),
+			13: linksTo(14, 15),
+			14: linksTo(15, 17),
+			15: linksTo(16, 17),
+			16: nil,
+			17: linksTo(18, 19, 20),
+			18: linksTo(19, 20),
+			19: linksTo(20),
+			20: nil,
+		},
+		from:  concrete.Node(3),
+		final: map[graph.Node]bool{nil: true},
+		want:  []int{1, 2, 3, 4, 5},
+	},
+	{
+		g: []set{
+			0: nil,
+
+			1: linksTo(2, 3),
+			2: linksTo(4),
+			3: linksTo(4),
+			4: linksTo(5),
+			5: nil,
+
+			6:  linksTo(7, 8, 14),
+			7:  linksTo(8, 11, 12, 14),
+			8:  linksTo(14),
+			9:  linksTo(11),
+			10: linksTo(11),
+			11: linksTo(12),
+			12: linksTo(18),
+			13: linksTo(14, 15),
+			14: linksTo(15, 17),
+			15: linksTo(16, 17),
+			16: nil,
+			17: linksTo(18, 19, 20),
+			18: linksTo(19, 20),
+			19: linksTo(20),
+			20: nil,
+		},
+		from:  concrete.Node(13),
+		final: map[graph.Node]bool{nil: true},
+		want:  []int{6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20},
+	},
+}
+
+func TestDepthFirst(t *testing.T) {
+	for i, test := range depthFirstTests {
+		g := concrete.NewGraph()
+		for u, e := range test.g {
+			if !g.NodeExists(concrete.Node(u)) {
+				g.AddNode(concrete.Node(u))
+			}
+			for v := range e {
+				if !g.NodeExists(concrete.Node(v)) {
+					g.AddNode(concrete.Node(v))
+				}
+				g.AddUndirectedEdge(concrete.Edge{H: concrete.Node(u), T: concrete.Node(v)}, 0)
+			}
+		}
+		w := traverse.DepthFirst{
+			EdgeFilter: test.edge,
+		}
+		var got []int
+		final := w.Walk(g, test.from, func(n graph.Node) bool {
+			if test.until != nil && test.until(n) {
+				return true
+			}
+			got = append(got, n.ID())
+			return false
+		})
+		if !test.final[final] {
+			t.Errorf("unexepected final node for test %d:\ngot:  %v\nwant: %v", i, final, test.final)
+		}
+		sort.Ints(got)
+		if test.want != nil && !reflect.DeepEqual(got, test.want) {
+			t.Errorf("unexepected DFS traversed nodes for test %d:\ngot:  %v\nwant: %v", i, got, test.want)
+		}
+	}
+}
+
+// set is an integer set.
+type set map[int]struct{}
+
+func linksTo(i ...int) set {
+	if len(i) == 0 {
+		return nil
+	}
+	s := make(set)
+	for _, v := range i {
+		s[v] = struct{}{}
+	}
+	return s
+}


### PR DESCRIPTION
This adds a new package, traverse, that provides basic and very generalisable stateful graph traversal primitives. These are intended to be used as building blocks for broader algorithms, e.g. connected components would use a Walk methods in conjunction with the associated Visited method to avoid continual reallocation of visited structures.

We already have a DepthFirstSearch function in search and AStar may be used as breadth first, but these return paths, rather than allowing arbitrary operations on the traversed edges and node. Additionally, AStar is much heavier than a simple breadth-first.