### PR TITLE
{search,traverse}: clean up after recent changes

### DIFF
--- a/internal/set.go
+++ b/internal/set.go
@@ -4,29 +4,29 @@
 
 package internal
 
-// A set is a set of integer identifiers.
+// IntSet is a set of integer identifiers.
 type IntSet map[int]struct{}
 
 // The simple accessor methods for Set are provided to allow ease of
 // implementation change should the need arise.
 
-// add inserts an element into the set.
+// Add inserts an element into the set.
 func (s IntSet) Add(e int) {
 	s[e] = struct{}{}
 }
 
-// has reports the existence of the element in the set.
+// Has reports the existence of the element in the set.
 func (s IntSet) Has(e int) bool {
 	_, ok := s[e]
 	return ok
 }
 
-// remove deletes the specified element from the set.
+// Remove deletes the specified element from the set.
 func (s IntSet) Remove(e int) {
 	delete(s, e)
 }
 
-// count reports the number of elements stored in the set.
+// Count reports the number of elements stored in the set.
 func (s IntSet) Count() int {
 	return len(s)
 }

--- a/internal/set.go
+++ b/internal/set.go
@@ -1,0 +1,32 @@
+// Copyright ©2015 The gonum Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package internal
+
+// A set is a set of integer identifiers.
+type IntSet map[int]struct{}
+
+// The simple accessor methods for Set are provided to allow ease of
+// implementation change should the need arise.
+
+// add inserts an element into the set.
+func (s IntSet) Add(e int) {
+	s[e] = struct{}{}
+}
+
+// has reports the existence of the element in the set.
+func (s IntSet) Has(e int) bool {
+	_, ok := s[e]
+	return ok
+}
+
+// remove deletes the specified element from the set.
+func (s IntSet) Remove(e int) {
+	delete(s, e)
+}
+
+// count reports the number of elements stored in the set.
+func (s IntSet) Count() int {
+	return len(s)
+}

--- a/internal/sort.go
+++ b/internal/sort.go
@@ -1,0 +1,34 @@
+// Copyright ©2015 The gonum Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package internal
+
+type ByComponentLengthOrStart [][]int
+
+func (c ByComponentLengthOrStart) Len() int { return len(c) }
+func (c ByComponentLengthOrStart) Less(i, j int) bool {
+	return len(c[i]) < len(c[j]) || (len(c[i]) == len(c[j]) && c[i][0] < c[j][0])
+}
+func (c ByComponentLengthOrStart) Swap(i, j int) { c[i], c[j] = c[j], c[i] }
+
+type BySliceValues [][]int
+
+func (c BySliceValues) Len() int { return len(c) }
+func (c BySliceValues) Less(i, j int) bool {
+	a, b := c[i], c[j]
+	l := len(a)
+	if len(b) < l {
+		l = len(b)
+	}
+	for k, v := range a[:l] {
+		if v < b[k] {
+			return true
+		}
+		if v > b[k] {
+			return false
+		}
+	}
+	return len(a) < len(b)
+}
+func (c BySliceValues) Swap(i, j int) { c[i], c[j] = c[j], c[i] }

--- a/internal/sort.go
+++ b/internal/sort.go
@@ -4,14 +4,8 @@
 
 package internal
 
-type ByComponentLengthOrStart [][]int
-
-func (c ByComponentLengthOrStart) Len() int { return len(c) }
-func (c ByComponentLengthOrStart) Less(i, j int) bool {
-	return len(c[i]) < len(c[j]) || (len(c[i]) == len(c[j]) && c[i][0] < c[j][0])
-}
-func (c ByComponentLengthOrStart) Swap(i, j int) { c[i], c[j] = c[j], c[i] }
-
+// BySliceValues implements the sort.Interface sorting a slice of
+// []int lexically by the values of the []int.
 type BySliceValues [][]int
 
 func (c BySliceValues) Len() int { return len(c) }

--- a/search/graph_search.go
+++ b/search/graph_search.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/gonum/graph"
 	"github.com/gonum/graph/concrete"
+	"github.com/gonum/graph/internal"
 	"github.com/gonum/graph/traverse"
 )
 
@@ -288,14 +289,14 @@ func DepthFirstSearch(start, goal graph.Node, g graph.Graph) []graph.Node {
 	sf := setupFuncs(g, nil, nil)
 	successors := sf.successors
 
-	closedSet := make(intSet)
+	closedSet := make(internal.IntSet)
 	openSet := &nodeStack{start}
 	predecessor := make(map[int]graph.Node)
 
 	for openSet.len() != 0 {
 		curr := openSet.pop()
 
-		if closedSet.has(curr.ID()) {
+		if closedSet.Has(curr.ID()) {
 			continue
 		}
 
@@ -303,10 +304,10 @@ func DepthFirstSearch(start, goal graph.Node, g graph.Graph) []graph.Node {
 			return rebuildPath(predecessor, goal)
 		}
 
-		closedSet.add(curr.ID())
+		closedSet.Add(curr.ID())
 
 		for _, neighbor := range successors(curr) {
-			if closedSet.has(neighbor.ID()) {
+			if closedSet.Has(neighbor.ID()) {
 				continue
 			}
 
@@ -386,7 +387,7 @@ func TarjanSCC(g graph.DirectedGraph) [][]graph.Node {
 
 		indexTable: make(map[int]int, len(nodes)),
 		lowLink:    make(map[int]int, len(nodes)),
-		onStack:    make(intSet, len(nodes)),
+		onStack:    make(internal.IntSet, len(nodes)),
 	}
 	for _, v := range nodes {
 		if t.indexTable[v.ID()] == 0 {
@@ -407,7 +408,7 @@ type tarjan struct {
 	index      int
 	indexTable map[int]int
 	lowLink    map[int]int
-	onStack    intSet
+	onStack    internal.IntSet
 
 	stack []graph.Node
 
@@ -424,7 +425,7 @@ func (t *tarjan) strongconnect(v graph.Node) {
 	t.indexTable[vID] = t.index
 	t.lowLink[vID] = t.index
 	t.stack = append(t.stack, v)
-	t.onStack.add(vID)
+	t.onStack.Add(vID)
 
 	// Consider successors of v.
 	for _, w := range t.succ(v) {
@@ -433,7 +434,7 @@ func (t *tarjan) strongconnect(v graph.Node) {
 			// Successor w has not yet been visited; recur on it.
 			t.strongconnect(w)
 			t.lowLink[vID] = min(t.lowLink[vID], t.lowLink[wID])
-		} else if t.onStack.has(wID) {
+		} else if t.onStack.Has(wID) {
 			// Successor w is in stack s and hence in the current SCC.
 			t.lowLink[vID] = min(t.lowLink[vID], t.indexTable[wID])
 		}
@@ -448,7 +449,7 @@ func (t *tarjan) strongconnect(v graph.Node) {
 		)
 		for {
 			w, t.stack = t.stack[len(t.stack)-1], t.stack[:len(t.stack)-1]
-			t.onStack.remove(w.ID())
+			t.onStack.Remove(w.ID())
 			// Add w to current strongly connected component.
 			scc = append(scc, w)
 			if w.ID() == vID {
@@ -507,17 +508,17 @@ func Prim(dst graph.MutableGraph, g graph.EdgeListGraph, cost graph.CostFunc) {
 	}
 
 	dst.AddNode(nlist[0])
-	remainingNodes := make(intSet)
+	remainingNodes := make(internal.IntSet)
 	for _, node := range nlist[1:] {
-		remainingNodes.add(node.ID())
+		remainingNodes.Add(node.ID())
 	}
 
 	edgeList := g.EdgeList()
-	for remainingNodes.count() != 0 {
+	for remainingNodes.Count() != 0 {
 		var edges []concrete.WeightedEdge
 		for _, edge := range edgeList {
-			if (dst.NodeExists(edge.Head()) && remainingNodes.has(edge.Tail().ID())) ||
-				(dst.NodeExists(edge.Tail()) && remainingNodes.has(edge.Head().ID())) {
+			if (dst.NodeExists(edge.Head()) && remainingNodes.Has(edge.Tail().ID())) ||
+				(dst.NodeExists(edge.Tail()) && remainingNodes.Has(edge.Head().ID())) {
 
 				edges = append(edges, concrete.WeightedEdge{Edge: edge, Cost: cost(edge)})
 			}
@@ -527,7 +528,7 @@ func Prim(dst graph.MutableGraph, g graph.EdgeListGraph, cost graph.CostFunc) {
 		myEdge := edges[0]
 
 		dst.AddUndirectedEdge(myEdge.Edge, myEdge.Cost)
-		remainingNodes.remove(myEdge.Edge.Head().ID())
+		remainingNodes.Remove(myEdge.Edge.Head().ID())
 	}
 
 }

--- a/search/johnson_cycles_test.go
+++ b/search/johnson_cycles_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 
 	"github.com/gonum/graph/concrete"
+	"github.com/gonum/graph/internal"
 	"github.com/gonum/graph/search"
 )
 
@@ -77,8 +78,8 @@ var cyclesInTests = []struct {
 			4: linksTo(3),
 		},
 		want: [][]int{
-			{3, 4, 3},
 			{0, 1, 2, 0},
+			{3, 4, 3},
 		},
 	},
 }
@@ -112,7 +113,7 @@ func TestCyclesIn(t *testing.T) {
 			}
 			got[j] = ids
 		}
-		sort.Sort(byComponentLengthOrStart(got))
+		sort.Sort(internal.BySliceValues(got))
 		if !reflect.DeepEqual(got, test.want) {
 			t.Errorf("unexpected johnson result for %d:\n\tgot:%#v\n\twant:%#v", i, got, test.want)
 		}

--- a/search/search_test.go
+++ b/search/search_test.go
@@ -361,7 +361,8 @@ var tarjanTests = []struct {
 			{0, 2},
 		},
 		want: [][]int{
-			{3, 4}, {0, 1, 2},
+			{0, 1, 2},
+			{3, 4},
 		},
 	},
 }
@@ -390,8 +391,8 @@ func TestTarjanSCC(t *testing.T) {
 			sort.Ints(gotIDs[i])
 		}
 		for _, iv := range test.ambiguousOrder {
-			sort.Sort(internal.ByComponentLengthOrStart(test.want[iv.start:iv.end]))
-			sort.Sort(internal.ByComponentLengthOrStart(gotIDs[iv.start:iv.end]))
+			sort.Sort(internal.BySliceValues(test.want[iv.start:iv.end]))
+			sort.Sort(internal.BySliceValues(gotIDs[iv.start:iv.end]))
 		}
 		if !reflect.DeepEqual(gotIDs, test.want) {
 			t.Errorf("unexpected Tarjan scc result for %d:\n\tgot:%v\n\twant:%v", i, gotIDs, test.want)

--- a/search/search_test.go
+++ b/search/search_test.go
@@ -398,6 +398,34 @@ func TestTarjanSCC(t *testing.T) {
 	}
 }
 
+// batageljZaversnikGraph is the example graph from
+// figure 1 of http://arxiv.org/abs/cs/0310049v1
+var batageljZaversnikGraph = []set{
+	0: nil,
+
+	1: linksTo(2, 3),
+	2: linksTo(4),
+	3: linksTo(4),
+	4: linksTo(5),
+	5: nil,
+
+	6:  linksTo(7, 8, 14),
+	7:  linksTo(8, 11, 12, 14),
+	8:  linksTo(14),
+	9:  linksTo(11),
+	10: linksTo(11),
+	11: linksTo(12),
+	12: linksTo(18),
+	13: linksTo(14, 15),
+	14: linksTo(15, 17),
+	15: linksTo(16, 17),
+	16: nil,
+	17: linksTo(18, 19, 20),
+	18: linksTo(19, 20),
+	19: linksTo(20),
+	20: nil,
+}
+
 var vOrderTests = []struct {
 	g        []set
 	wantCore [][]int
@@ -421,32 +449,8 @@ var vOrderTests = []struct {
 		},
 		wantK: 3,
 	},
-	{ // This is the example graph from figure 1 of http://arxiv.org/abs/cs/0310049v1
-		g: []set{
-			0: nil,
-
-			1: linksTo(2, 3),
-			2: linksTo(4),
-			3: linksTo(4),
-			4: linksTo(5),
-			5: nil,
-
-			6:  linksTo(7, 8, 14),
-			7:  linksTo(8, 11, 12, 14),
-			8:  linksTo(14),
-			9:  linksTo(11),
-			10: linksTo(11),
-			11: linksTo(12),
-			12: linksTo(18),
-			13: linksTo(14, 15),
-			14: linksTo(15, 17),
-			15: linksTo(16, 17),
-			16: nil,
-			17: linksTo(18, 19, 20),
-			18: linksTo(19, 20),
-			19: linksTo(20),
-			20: nil,
-		},
+	{
+		g: batageljZaversnikGraph,
 		wantCore: [][]int{
 			{0},
 			{5, 9, 10, 16},
@@ -522,32 +526,8 @@ var bronKerboschTests = []struct {
 			{3, 5},
 		},
 	},
-	{ // This is the example graph from figure 1 of http://arxiv.org/abs/cs/0310049v1
-		g: []set{
-			0: nil,
-
-			1: linksTo(2, 3),
-			2: linksTo(4),
-			3: linksTo(4),
-			4: linksTo(5),
-			5: nil,
-
-			6:  linksTo(7, 8, 14),
-			7:  linksTo(8, 11, 12, 14),
-			8:  linksTo(14),
-			9:  linksTo(11),
-			10: linksTo(11),
-			11: linksTo(12),
-			12: linksTo(18),
-			13: linksTo(14, 15),
-			14: linksTo(15, 17),
-			15: linksTo(16, 17),
-			16: nil,
-			17: linksTo(18, 19, 20),
-			18: linksTo(19, 20),
-			19: linksTo(20),
-			20: nil,
-		},
+	{
+		g: batageljZaversnikGraph,
 		want: [][]int{
 			{0},
 			{1, 2},
@@ -603,32 +583,8 @@ var connectedComponentTests = []struct {
 	g    []set
 	want [][]int
 }{
-	{ // This is the example graph from figure 1 of http://arxiv.org/abs/cs/0310049v1
-		g: []set{
-			0: nil,
-
-			1: linksTo(2, 3),
-			2: linksTo(4),
-			3: linksTo(4),
-			4: linksTo(5),
-			5: nil,
-
-			6:  linksTo(7, 8, 14),
-			7:  linksTo(8, 11, 12, 14),
-			8:  linksTo(14),
-			9:  linksTo(11),
-			10: linksTo(11),
-			11: linksTo(12),
-			12: linksTo(18),
-			13: linksTo(14, 15),
-			14: linksTo(15, 17),
-			15: linksTo(16, 17),
-			16: nil,
-			17: linksTo(18, 19, 20),
-			18: linksTo(19, 20),
-			19: linksTo(20),
-			20: nil,
-		},
+	{
+		g: batageljZaversnikGraph,
 		want: [][]int{
 			{0},
 			{1, 2, 3, 4, 5},

--- a/search/search_test.go
+++ b/search/search_test.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/gonum/graph"
 	"github.com/gonum/graph/concrete"
+	"github.com/gonum/graph/internal"
 	"github.com/gonum/graph/search"
 )
 
@@ -389,8 +390,8 @@ func TestTarjanSCC(t *testing.T) {
 			sort.Ints(gotIDs[i])
 		}
 		for _, iv := range test.ambiguousOrder {
-			sort.Sort(byComponentLengthOrStart(test.want[iv.start:iv.end]))
-			sort.Sort(byComponentLengthOrStart(gotIDs[iv.start:iv.end]))
+			sort.Sort(internal.ByComponentLengthOrStart(test.want[iv.start:iv.end]))
+			sort.Sort(internal.ByComponentLengthOrStart(gotIDs[iv.start:iv.end]))
 		}
 		if !reflect.DeepEqual(gotIDs, test.want) {
 			t.Errorf("unexpected Tarjan scc result for %d:\n\tgot:%v\n\twant:%v", i, gotIDs, test.want)
@@ -572,7 +573,7 @@ func TestBronKerbosch(t *testing.T) {
 			sort.Ints(ids)
 			got[j] = ids
 		}
-		sort.Sort(bySliceValues(got))
+		sort.Sort(internal.BySliceValues(got))
 		if !reflect.DeepEqual(got, test.want) {
 			t.Errorf("unexpected cliques for test %d:\ngot: %v\nwant:%v", i, got, test.want)
 		}
@@ -631,7 +632,7 @@ func TestConnectedComponents(t *testing.T) {
 				sort.Ints(ids)
 				got[j] = ids
 			}
-			sort.Sort(bySliceValues(got))
+			sort.Sort(internal.BySliceValues(got))
 			if !reflect.DeepEqual(got, test.want) {
 				t.Errorf("unexpected connected components for test %d:\ngot: %v\nwant:%v", i, got, test.want)
 			}
@@ -652,32 +653,3 @@ func linksTo(i ...int) set {
 	}
 	return s
 }
-
-type byComponentLengthOrStart [][]int
-
-func (c byComponentLengthOrStart) Len() int { return len(c) }
-func (c byComponentLengthOrStart) Less(i, j int) bool {
-	return len(c[i]) < len(c[j]) || (len(c[i]) == len(c[j]) && c[i][0] < c[j][0])
-}
-func (c byComponentLengthOrStart) Swap(i, j int) { c[i], c[j] = c[j], c[i] }
-
-type bySliceValues [][]int
-
-func (c bySliceValues) Len() int { return len(c) }
-func (c bySliceValues) Less(i, j int) bool {
-	a, b := c[i], c[j]
-	l := len(a)
-	if len(b) < l {
-		l = len(b)
-	}
-	for k, v := range a[:l] {
-		if v < b[k] {
-			return true
-		}
-		if v > b[k] {
-			return false
-		}
-	}
-	return len(a) < len(b)
-}
-func (c bySliceValues) Swap(i, j int) { c[i], c[j] = c[j], c[i] }

--- a/search/set.go
+++ b/search/set.go
@@ -10,33 +10,6 @@ import (
 	"github.com/gonum/graph"
 )
 
-// A set is a set of integer identifiers.
-type intSet map[int]struct{}
-
-// The simple accessor methods for Set are provided to allow ease of
-// implementation change should the need arise.
-
-// add inserts an element into the set.
-func (s intSet) add(e int) {
-	s[e] = struct{}{}
-}
-
-// has reports the existence of the element in the set.
-func (s intSet) has(e int) bool {
-	_, ok := s[e]
-	return ok
-}
-
-// remove deletes the specified element from the set.
-func (s intSet) remove(e int) {
-	delete(s, e)
-}
-
-// count reports the number of elements stored in the set.
-func (s intSet) count() int {
-	return len(s)
-}
-
 // same determines whether two sets are backed by the same store. In the
 // current implementation using hash maps it makes use of the fact that
 // hash maps (at least in the gc implementation) are passed as a pointer

--- a/traverse/traverse.go
+++ b/traverse/traverse.go
@@ -5,14 +5,17 @@
 // Package traverse provides basic graph traversal primitives.
 package traverse
 
-import "github.com/gonum/graph"
+import (
+	"github.com/gonum/graph"
+	"github.com/gonum/graph/internal"
+)
 
 // BreadthFirst implements stateful breadth-first graph traversal.
 type BreadthFirst struct {
 	EdgeFilter func(graph.Edge) bool
 	Visit      func(u, v graph.Node)
 	queue      nodeQueue
-	visited    intSet
+	visited    internal.IntSet
 }
 
 // Walk performs a breadth-first traversal of the graph g starting from the given node,
@@ -30,10 +33,10 @@ func (b *BreadthFirst) Walk(g graph.Graph, from graph.Node, until func(n graph.N
 	}
 
 	if b.visited == nil {
-		b.visited = make(intSet)
+		b.visited = make(internal.IntSet)
 	}
 	b.queue.enqueue(from)
-	b.visited.add(from.ID())
+	b.visited.Add(from.ID())
 
 	var (
 		depth     int
@@ -49,13 +52,13 @@ func (b *BreadthFirst) Walk(g graph.Graph, from graph.Node, until func(n graph.N
 			if b.EdgeFilter != nil && !b.EdgeFilter(g.EdgeBetween(t, n)) {
 				continue
 			}
-			if b.visited.has(n.ID()) {
+			if b.visited.Has(n.ID()) {
 				continue
 			}
 			if b.Visit != nil {
 				b.Visit(t, n)
 			}
-			b.visited.add(n.ID())
+			b.visited.Add(n.ID())
 			children++
 			b.queue.enqueue(n)
 		}
@@ -116,7 +119,7 @@ type DepthFirst struct {
 	EdgeFilter func(graph.Edge) bool
 	Visit      func(u, v graph.Node)
 	stack      nodeStack
-	visited    intSet
+	visited    internal.IntSet
 }
 
 // Walk performs a depth-first traversal of the graph g starting from the given node,
@@ -134,10 +137,10 @@ func (d *DepthFirst) Walk(g graph.Graph, from graph.Node, until func(graph.Node)
 	}
 
 	if d.visited == nil {
-		d.visited = make(intSet)
+		d.visited = make(internal.IntSet)
 	}
 	d.stack.push(from)
-	d.visited.add(from.ID())
+	d.visited.Add(from.ID())
 
 	for d.stack.len() > 0 {
 		t := d.stack.pop()
@@ -148,13 +151,13 @@ func (d *DepthFirst) Walk(g graph.Graph, from graph.Node, until func(graph.Node)
 			if d.EdgeFilter != nil && !d.EdgeFilter(g.EdgeBetween(t, n)) {
 				continue
 			}
-			if d.visited.has(n.ID()) {
+			if d.visited.Has(n.ID()) {
 				continue
 			}
 			if d.Visit != nil {
 				d.Visit(t, n)
 			}
-			d.visited.add(n.ID())
+			d.visited.Add(n.ID())
 			d.stack.push(n)
 		}
 	}
@@ -247,31 +250,4 @@ func (q *nodeQueue) dequeue() graph.Node {
 	}
 
 	return n
-}
-
-// A set is a set of integer identifiers.
-type intSet map[int]struct{}
-
-// The simple accessor methods for Set are provided to allow ease of
-// implementation change should the need arise.
-
-// add inserts an element into the set.
-func (s intSet) add(e int) {
-	s[e] = struct{}{}
-}
-
-// has reports the existence of the element in the set.
-func (s intSet) has(e int) bool {
-	_, ok := s[e]
-	return ok
-}
-
-// remove deletes the specified element from the set.
-func (s intSet) remove(e int) {
-	delete(s, e)
-}
-
-// count reports the number of elements stored in the set.
-func (s intSet) count() int {
-	return len(s)
 }

--- a/traverse/traverse_test.go
+++ b/traverse/traverse_test.go
@@ -15,6 +15,47 @@ import (
 	"github.com/gonum/graph/traverse"
 )
 
+var (
+	// batageljZaversnikGraph is the example graph from
+	// figure 1 of http://arxiv.org/abs/cs/0310049v1
+	batageljZaversnikGraph = []set{
+		0: nil,
+
+		1: linksTo(2, 3),
+		2: linksTo(4),
+		3: linksTo(4),
+		4: linksTo(5),
+		5: nil,
+
+		6:  linksTo(7, 8, 14),
+		7:  linksTo(8, 11, 12, 14),
+		8:  linksTo(14),
+		9:  linksTo(11),
+		10: linksTo(11),
+		11: linksTo(12),
+		12: linksTo(18),
+		13: linksTo(14, 15),
+		14: linksTo(15, 17),
+		15: linksTo(16, 17),
+		16: nil,
+		17: linksTo(18, 19, 20),
+		18: linksTo(19, 20),
+		19: linksTo(20),
+		20: nil,
+	}
+
+	// wpBronKerboschGraph is the example given in the Bron-Kerbosch article on wikipedia (renumbered).
+	// http://en.wikipedia.org/w/index.php?title=Bron%E2%80%93Kerbosch_algorithm&oldid=656805858
+	wpBronKerboschGraph = []set{
+		0: linksTo(1, 4),
+		1: linksTo(2, 4),
+		2: linksTo(3),
+		3: linksTo(4, 5),
+		4: nil,
+		5: nil,
+	}
+)
+
 var breadthFirstTests = []struct {
 	g     []set
 	from  graph.Node
@@ -24,14 +65,7 @@ var breadthFirstTests = []struct {
 	want  [][]int
 }{
 	{
-		g: []set{
-			0: linksTo(1, 4),
-			1: linksTo(2, 4),
-			2: linksTo(3),
-			3: linksTo(4, 5),
-			4: nil,
-			5: nil,
-		},
+		g:     wpBronKerboschGraph,
 		from:  concrete.Node(1),
 		final: map[graph.Node]bool{nil: true},
 		want: [][]int{
@@ -42,14 +76,7 @@ var breadthFirstTests = []struct {
 		},
 	},
 	{
-		g: []set{
-			0: linksTo(1, 4),
-			1: linksTo(2, 4),
-			2: linksTo(3),
-			3: linksTo(4, 5),
-			4: nil,
-			5: nil,
-		},
+		g: wpBronKerboschGraph,
 		edge: func(e graph.Edge) bool {
 			// Do not traverse an edge between 3 and 5.
 			return (e.Head().ID() != 3 || e.Tail().ID() != 5) && (e.Head().ID() != 5 || e.Tail().ID() != 3)
@@ -63,14 +90,7 @@ var breadthFirstTests = []struct {
 		},
 	},
 	{
-		g: []set{
-			0: linksTo(1, 4),
-			1: linksTo(2, 4),
-			2: linksTo(3),
-			3: linksTo(4, 5),
-			4: nil,
-			5: nil,
-		},
+		g:     wpBronKerboschGraph,
 		from:  concrete.Node(1),
 		until: func(n graph.Node, _ int) bool { return n == concrete.Node(3) },
 		final: map[graph.Node]bool{concrete.Node(3): true},
@@ -80,31 +100,7 @@ var breadthFirstTests = []struct {
 		},
 	},
 	{
-		g: []set{
-			0: nil,
-
-			1: linksTo(2, 3),
-			2: linksTo(4),
-			3: linksTo(4),
-			4: linksTo(5),
-			5: nil,
-
-			6:  linksTo(7, 8, 14),
-			7:  linksTo(8, 11, 12, 14),
-			8:  linksTo(14),
-			9:  linksTo(11),
-			10: linksTo(11),
-			11: linksTo(12),
-			12: linksTo(18),
-			13: linksTo(14, 15),
-			14: linksTo(15, 17),
-			15: linksTo(16, 17),
-			16: nil,
-			17: linksTo(18, 19, 20),
-			18: linksTo(19, 20),
-			19: linksTo(20),
-			20: nil,
-		},
+		g:     batageljZaversnikGraph,
 		from:  concrete.Node(13),
 		final: map[graph.Node]bool{nil: true},
 		want: [][]int{
@@ -116,31 +112,7 @@ var breadthFirstTests = []struct {
 		},
 	},
 	{
-		g: []set{
-			0: nil,
-
-			1: linksTo(2, 3),
-			2: linksTo(4),
-			3: linksTo(4),
-			4: linksTo(5),
-			5: nil,
-
-			6:  linksTo(7, 8, 14),
-			7:  linksTo(8, 11, 12, 14),
-			8:  linksTo(14),
-			9:  linksTo(11),
-			10: linksTo(11),
-			11: linksTo(12),
-			12: linksTo(18),
-			13: linksTo(14, 15),
-			14: linksTo(15, 17),
-			15: linksTo(16, 17),
-			16: nil,
-			17: linksTo(18, 19, 20),
-			18: linksTo(19, 20),
-			19: linksTo(20),
-			20: nil,
-		},
+		g:     batageljZaversnikGraph,
 		from:  concrete.Node(13),
 		until: func(_ graph.Node, d int) bool { return d > 2 },
 		final: map[graph.Node]bool{
@@ -207,27 +179,13 @@ var depthFirstTests = []struct {
 	want  []int
 }{
 	{
-		g: []set{
-			0: linksTo(1, 4),
-			1: linksTo(2, 4),
-			2: linksTo(3),
-			3: linksTo(4, 5),
-			4: nil,
-			5: nil,
-		},
+		g:     wpBronKerboschGraph,
 		from:  concrete.Node(1),
 		final: map[graph.Node]bool{nil: true},
 		want:  []int{0, 1, 2, 3, 4, 5},
 	},
 	{
-		g: []set{
-			0: linksTo(1, 4),
-			1: linksTo(2, 4),
-			2: linksTo(3),
-			3: linksTo(4, 5),
-			4: nil,
-			5: nil,
-		},
+		g: wpBronKerboschGraph,
 		edge: func(e graph.Edge) bool {
 			// Do not traverse an edge between 3 and 5.
 			return (e.Head().ID() != 3 || e.Tail().ID() != 5) && (e.Head().ID() != 5 || e.Tail().ID() != 3)
@@ -237,104 +195,25 @@ var depthFirstTests = []struct {
 		want:  []int{0, 1, 2, 3, 4},
 	},
 	{
-		g: []set{
-			0: linksTo(1, 4),
-			1: linksTo(2, 4),
-			2: linksTo(3),
-			3: linksTo(4, 5),
-			4: nil,
-			5: nil,
-		},
+		g:     wpBronKerboschGraph,
 		from:  concrete.Node(1),
 		until: func(n graph.Node) bool { return n == concrete.Node(3) },
 		final: map[graph.Node]bool{concrete.Node(3): true},
 	},
 	{
-		g: []set{
-			0: nil,
-
-			1: linksTo(2, 3),
-			2: linksTo(4),
-			3: linksTo(4),
-			4: linksTo(5),
-			5: nil,
-
-			6:  linksTo(7, 8, 14),
-			7:  linksTo(8, 11, 12, 14),
-			8:  linksTo(14),
-			9:  linksTo(11),
-			10: linksTo(11),
-			11: linksTo(12),
-			12: linksTo(18),
-			13: linksTo(14, 15),
-			14: linksTo(15, 17),
-			15: linksTo(16, 17),
-			16: nil,
-			17: linksTo(18, 19, 20),
-			18: linksTo(19, 20),
-			19: linksTo(20),
-			20: nil,
-		},
+		g:     batageljZaversnikGraph,
 		from:  concrete.Node(0),
 		final: map[graph.Node]bool{nil: true},
 		want:  []int{0},
 	},
 	{
-		g: []set{
-			0: nil,
-
-			1: linksTo(2, 3),
-			2: linksTo(4),
-			3: linksTo(4),
-			4: linksTo(5),
-			5: nil,
-
-			6:  linksTo(7, 8, 14),
-			7:  linksTo(8, 11, 12, 14),
-			8:  linksTo(14),
-			9:  linksTo(11),
-			10: linksTo(11),
-			11: linksTo(12),
-			12: linksTo(18),
-			13: linksTo(14, 15),
-			14: linksTo(15, 17),
-			15: linksTo(16, 17),
-			16: nil,
-			17: linksTo(18, 19, 20),
-			18: linksTo(19, 20),
-			19: linksTo(20),
-			20: nil,
-		},
+		g:     batageljZaversnikGraph,
 		from:  concrete.Node(3),
 		final: map[graph.Node]bool{nil: true},
 		want:  []int{1, 2, 3, 4, 5},
 	},
 	{
-		g: []set{
-			0: nil,
-
-			1: linksTo(2, 3),
-			2: linksTo(4),
-			3: linksTo(4),
-			4: linksTo(5),
-			5: nil,
-
-			6:  linksTo(7, 8, 14),
-			7:  linksTo(8, 11, 12, 14),
-			8:  linksTo(14),
-			9:  linksTo(11),
-			10: linksTo(11),
-			11: linksTo(12),
-			12: linksTo(18),
-			13: linksTo(14, 15),
-			14: linksTo(15, 17),
-			15: linksTo(16, 17),
-			16: nil,
-			17: linksTo(18, 19, 20),
-			18: linksTo(19, 20),
-			19: linksTo(20),
-			20: nil,
-		},
+		g:     batageljZaversnikGraph,
 		from:  concrete.Node(13),
 		final: map[graph.Node]bool{nil: true},
 		want:  []int{6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20},
@@ -381,64 +260,16 @@ var walkAllTests = []struct {
 	edge func(graph.Edge) bool
 	want [][]int
 }{
-	{ // This is the example graph from figure 1 of http://arxiv.org/abs/cs/0310049v1
-		g: []set{
-			0: nil,
-
-			1: linksTo(2, 3),
-			2: linksTo(4),
-			3: linksTo(4),
-			4: linksTo(5),
-			5: nil,
-
-			6:  linksTo(7, 8, 14),
-			7:  linksTo(8, 11, 12, 14),
-			8:  linksTo(14),
-			9:  linksTo(11),
-			10: linksTo(11),
-			11: linksTo(12),
-			12: linksTo(18),
-			13: linksTo(14, 15),
-			14: linksTo(15, 17),
-			15: linksTo(16, 17),
-			16: nil,
-			17: linksTo(18, 19, 20),
-			18: linksTo(19, 20),
-			19: linksTo(20),
-			20: nil,
-		},
+	{
+		g: batageljZaversnikGraph,
 		want: [][]int{
 			{0},
 			{1, 2, 3, 4, 5},
 			{6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20},
 		},
 	},
-	{ // This is the example graph from figure 1 of http://arxiv.org/abs/cs/0310049v1
-		g: []set{
-			0: nil,
-
-			1: linksTo(2, 3),
-			2: linksTo(4),
-			3: linksTo(4),
-			4: linksTo(5),
-			5: nil,
-
-			6:  linksTo(7, 8, 14),
-			7:  linksTo(8, 11, 12, 14),
-			8:  linksTo(14),
-			9:  linksTo(11),
-			10: linksTo(11),
-			11: linksTo(12),
-			12: linksTo(18),
-			13: linksTo(14, 15),
-			14: linksTo(15, 17),
-			15: linksTo(16, 17),
-			16: nil,
-			17: linksTo(18, 19, 20),
-			18: linksTo(19, 20),
-			19: linksTo(20),
-			20: nil,
-		},
+	{
+		g: batageljZaversnikGraph,
 		edge: func(e graph.Edge) bool {
 			// Do not traverse an edge between 3 and 5.
 			return (e.Head().ID() != 4 || e.Tail().ID() != 5) && (e.Head().ID() != 5 || e.Tail().ID() != 4)

--- a/traverse/traverse_test.go
+++ b/traverse/traverse_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/gonum/graph"
 	"github.com/gonum/graph/concrete"
+	"github.com/gonum/graph/internal"
 	"github.com/gonum/graph/traverse"
 )
 
@@ -349,7 +350,7 @@ func TestWalkAll(t *testing.T) {
 					sort.Ints(ids)
 					got[j] = ids
 				}
-				sort.Sort(bySliceValues(got))
+				sort.Sort(internal.BySliceValues(got))
 				if !reflect.DeepEqual(got, test.want) {
 					t.Errorf("unexpected connected components for test %d using %T:\ngot: %v\nwant:%v", i, w, got, test.want)
 				}
@@ -371,24 +372,3 @@ func linksTo(i ...int) set {
 	}
 	return s
 }
-
-type bySliceValues [][]int
-
-func (c bySliceValues) Len() int { return len(c) }
-func (c bySliceValues) Less(i, j int) bool {
-	a, b := c[i], c[j]
-	l := len(a)
-	if len(b) < l {
-		l = len(b)
-	}
-	for k, v := range a[:l] {
-		if v < b[k] {
-			return true
-		}
-		if v > b[k] {
-			return false
-		}
-	}
-	return len(a) < len(b)
-}
-func (c bySliceValues) Swap(i, j int) { c[i], c[j] = c[j], c[i] }


### PR DESCRIPTION
Add internal package for (most) shared unexported types and factor test example graphs into named values.