### PR TITLE
network: add more network analysis measures

### DIFF
--- a/network/betweenness.go
+++ b/network/betweenness.go
@@ -5,11 +5,19 @@
 package network
 
 import (
+	"math"
+
 	"github.com/gonum/graph"
 	"github.com/gonum/graph/internal"
+	"github.com/gonum/graph/search"
 )
 
-// Betweenness returns the betweenness centrality for nodes in the unweighted graph g.
+// Betweenness returns the non-zero betweenness centrality for nodes in the unweighted graph g.
+//
+//  C_B(v) = \sum_{s ≠ v ≠ t ∈ V} (\sigma_{st}(v) / \sigma_{st})
+//
+// where \sigma_{st} and \sigma_{st}(v) are number of the shortest paths from s to t,
+// and the subset of those paths containing v respectively.
 func Betweenness(g graph.Graph) map[int]float64 {
 	// Brandes' algorithm for finding betweenness centrality for nodes in
 	// and unweighted graph:
@@ -17,20 +25,17 @@ func Betweenness(g graph.Graph) map[int]float64 {
 	// http://www.inf.uni-konstanz.de/algo/publications/b-fabc-01.pdf
 
 	// TODO(kortschak): Consider using the parallel algorithm when
-	// GOMAXPROCS != 0.
+	// GOMAXPROCS != 1.
 	//
 	// http://htor.inf.ethz.ch/publications/img/edmonds-hoefler-lumsdaine-bc.pdf
 
 	// Also note special case for sparse networks:
 	// http://wwwold.iit.cnr.it/staff/marco.pellegrini/papiri/asonam-final.pdf
 
-	nodes := g.NodeList()
-	cb := make(map[int]float64, len(nodes))
-	for _, n := range nodes {
-		cb[n.ID()] = 0
-	}
-
 	var (
+		cb = make(map[int]float64)
+
+		nodes = g.NodeList()
 		stack internal.NodeStack
 		p     = make(map[int][]graph.Node, len(nodes))
 		sigma = make(map[int]float64, len(nodes))
@@ -80,7 +85,66 @@ func Betweenness(g graph.Graph) map[int]float64 {
 				delta[v.ID()] += sigma[v.ID()] / sigma[w.ID()] * (1 + delta[w.ID()])
 			}
 			if w.ID() != s.ID() {
-				cb[w.ID()] += delta[w.ID()]
+				if d := delta[w.ID()]; d != 0 {
+					cb[w.ID()] += d
+				}
+			}
+		}
+	}
+
+	return cb
+}
+
+// BetweennessWeighted returns the non-zero etweenness centrality for nodes in the weighted
+// graph g used to construct the given shortest paths.
+//
+//  C_B(v) = \sum_{s ≠ v ≠ t ∈ V} (\sigma_{st}(v) / \sigma_{st})
+//
+// where \sigma_{st} and \sigma_{st}(v) are number of the shortest paths from s to t.
+// and the subset of those paths containing v respectively.
+func BetweennessWeighted(g graph.CostGraph, p search.ShortestPaths) map[int]float64 {
+	cb := make(map[int]float64)
+
+	nodes := g.NodeList()
+	for i, s := range nodes {
+		for j, t := range nodes {
+			if i == j {
+				continue
+			}
+			d := p.Weight(s, t)
+			if math.IsInf(d, 0) {
+				continue
+			}
+
+			sID := s.ID()
+			tID := t.ID()
+
+			// If we have a unique path, don't do the
+			// extra work needed to get all paths.
+			path, _, unique := p.Between(s, t)
+			if unique {
+				for _, v := range path {
+					if vID := v.ID(); vID == sID || vID == tID {
+						continue
+					}
+					// For undirected graphs we double count
+					// passage though nodes. This is consistent
+					// with Brandes' algorithm's behaviour.
+					cb[v.ID()]++
+				}
+				continue
+			}
+
+			// Otherwise iterate over all paths.
+			paths, _ := p.AllBetween(s, t)
+			stFrac := 1 / float64(len(paths))
+			for _, path := range paths {
+				for _, v := range path {
+					if vID := v.ID(); vID == sID || vID == tID {
+						continue
+					}
+					cb[v.ID()] += stFrac
+				}
 			}
 		}
 	}

--- a/network/distance.go
+++ b/network/distance.go
@@ -1,0 +1,124 @@
+// Copyright ©2015 The gonum Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package network
+
+import (
+	"math"
+
+	"github.com/gonum/graph"
+	"github.com/gonum/graph/search"
+)
+
+// Closeness returns the closeness centrality for nodes in the graph g used to
+// construct the given shortest paths.
+//
+//  C(v) = 1 / \sum_u d(u,v)
+//
+// For directed graphs the incoming paths are used. Infinite distances are
+// not considered.
+func Closeness(g graph.Graph, p search.ShortestPaths) map[int]float64 {
+	nodes := g.NodeList()
+	c := make(map[int]float64, len(nodes))
+	for _, u := range nodes {
+		var sum float64
+		for _, v := range nodes {
+			// The ordering here is not relevant for
+			// undirected graphs, but we make sure we
+			// are counting incoming paths.
+			d := p.Weight(v, u)
+			if math.IsInf(d, 0) {
+				continue
+			}
+			sum += d
+		}
+		c[u.ID()] = 1 / sum
+	}
+	return c
+}
+
+// Farness returns the farness for nodes in the graph g used to construct
+// the given shortest paths.
+//
+//  F(v) = \sum_u d(u,v)
+//
+// For directed graphs the incoming paths are used. Infinite distances are
+// not considered.
+func Farness(g graph.Graph, p search.ShortestPaths) map[int]float64 {
+	nodes := g.NodeList()
+	f := make(map[int]float64, len(nodes))
+	for _, u := range nodes {
+		var sum float64
+		for _, v := range nodes {
+			// The ordering here is not relevant for
+			// undirected graphs, but we make sure we
+			// are counting incoming paths.
+			d := p.Weight(v, u)
+			if math.IsInf(d, 0) {
+				continue
+			}
+			sum += d
+		}
+		f[u.ID()] = sum
+	}
+	return f
+}
+
+// Harmonic returns the harmonic centrality for nodes in the graph g used to
+// construct the given shortest paths.
+//
+//  H(v)= \sum_{u ≠ v} 1 / d(u,v)
+//
+// For directed graphs the incoming paths are used. Infinite distances are
+// not considered.
+func Harmonic(g graph.Graph, p search.ShortestPaths) map[int]float64 {
+	nodes := g.NodeList()
+	h := make(map[int]float64, len(nodes))
+	for i, u := range nodes {
+		var sum float64
+		for j, v := range nodes {
+			// The ordering here is not relevant for
+			// undirected graphs, but we make sure we
+			// are counting incoming paths.
+			d := p.Weight(v, u)
+			if math.IsInf(d, 0) {
+				continue
+			}
+			if i != j {
+				sum += 1 / d
+			}
+		}
+		h[u.ID()] = sum
+	}
+	return h
+}
+
+// Residual returns the Dangalchev's residual closeness for nodes in the graph
+// g used to construct the given shortest paths.
+//
+//  C(v)= \sum_{u ≠ v} 1 / 2^d(u,v)
+//
+// For directed graphs the incoming paths are used. Infinite distances are
+// not considered.
+func Residual(g graph.Graph, p search.ShortestPaths) map[int]float64 {
+	nodes := g.NodeList()
+	r := make(map[int]float64, len(nodes))
+	for i, u := range nodes {
+		var sum float64
+		for j, v := range nodes {
+			// The ordering here is not relevant for
+			// undirected graphs, but we make sure we
+			// are counting incoming paths.
+			d := p.Weight(v, u)
+			if math.IsInf(d, 0) {
+				continue
+			}
+			if i != j {
+				sum += math.Exp2(-d)
+			}
+		}
+		r[u.ID()] = sum
+	}
+	return r
+}

--- a/network/distance_test.go
+++ b/network/distance_test.go
@@ -1,0 +1,398 @@
+// Copyright ©2015 The gonum Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package network
+
+import (
+	"math"
+	"testing"
+
+	"github.com/gonum/floats"
+	"github.com/gonum/graph/concrete"
+	"github.com/gonum/graph/search"
+)
+
+var undirectedCentralityTests = []struct {
+	g []set
+
+	farness  map[int]float64
+	harmonic map[int]float64
+	residual map[int]float64
+}{
+	{
+		g: []set{
+			A: linksTo(B),
+			B: linksTo(C),
+			C: nil,
+		},
+
+		farness: map[int]float64{
+			A: 1 + 2,
+			B: 1 + 1,
+			C: 2 + 1,
+		},
+		harmonic: map[int]float64{
+			A: 1 + 1.0/2.0,
+			B: 1 + 1,
+			C: 1.0/2.0 + 1,
+		},
+		residual: map[int]float64{
+			A: 1/math.Exp2(1) + 1/math.Exp2(2),
+			B: 1/math.Exp2(1) + 1/math.Exp2(1),
+			C: 1/math.Exp2(2) + 1/math.Exp2(1),
+		},
+	},
+	{
+		g: []set{
+			A: linksTo(B),
+			B: linksTo(C),
+			C: linksTo(D),
+			D: linksTo(E),
+			E: nil,
+		},
+
+		farness: map[int]float64{
+			A: 1 + 2 + 3 + 4,
+			B: 1 + 1 + 2 + 3,
+			C: 2 + 1 + 1 + 2,
+			D: 3 + 2 + 1 + 1,
+			E: 4 + 3 + 2 + 1,
+		},
+		harmonic: map[int]float64{
+			A: 1 + 1.0/2.0 + 1.0/3.0 + 1.0/4.0,
+			B: 1 + 1 + 1.0/2.0 + 1.0/3.0,
+			C: 1.0/2.0 + 1 + 1 + 1.0/2.0,
+			D: 1.0/3.0 + 1.0/2.0 + 1 + 1,
+			E: 1.0/4.0 + 1.0/3.0 + 1.0/2.0 + 1,
+		},
+		residual: map[int]float64{
+			A: 1/math.Exp2(1) + 1/math.Exp2(2) + 1/math.Exp2(3) + 1/math.Exp2(4),
+			B: 1/math.Exp2(1) + 1/math.Exp2(1) + 1/math.Exp2(2) + 1/math.Exp2(3),
+			C: 1/math.Exp2(2) + 1/math.Exp2(1) + 1/math.Exp2(1) + 1/math.Exp2(2),
+			D: 1/math.Exp2(3) + 1/math.Exp2(2) + 1/math.Exp2(1) + 1/math.Exp2(1),
+			E: 1/math.Exp2(4) + 1/math.Exp2(3) + 1/math.Exp2(2) + 1/math.Exp2(1),
+		},
+	},
+	{
+		g: []set{
+			A: linksTo(C),
+			B: linksTo(C),
+			C: nil,
+			D: linksTo(C),
+			E: linksTo(C),
+		},
+
+		farness: map[int]float64{
+			A: 2 + 2 + 1 + 2,
+			B: 2 + 1 + 2 + 2,
+			C: 1 + 1 + 1 + 1,
+			D: 2 + 1 + 2 + 2,
+			E: 2 + 2 + 1 + 2,
+		},
+		harmonic: map[int]float64{
+			A: 1.0/2.0 + 1.0/2.0 + 1 + 1.0/2.0,
+			B: 1.0/2.0 + 1 + 1.0/2.0 + 1.0/2.0,
+			C: 1 + 1 + 1 + 1,
+			D: 1.0/2.0 + 1 + 1.0/2.0 + 1.0/2.0,
+			E: 1.0/2.0 + 1.0/2.0 + 1 + 1.0/2.0,
+		},
+		residual: map[int]float64{
+			A: 1/math.Exp2(2) + 1/math.Exp2(2) + 1/math.Exp2(1) + 1/math.Exp2(2),
+			B: 1/math.Exp2(2) + 1/math.Exp2(1) + 1/math.Exp2(2) + 1/math.Exp2(2),
+			C: 1/math.Exp2(1) + 1/math.Exp2(1) + 1/math.Exp2(1) + 1/math.Exp2(1),
+			D: 1/math.Exp2(2) + 1/math.Exp2(1) + 1/math.Exp2(2) + 1/math.Exp2(2),
+			E: 1/math.Exp2(2) + 1/math.Exp2(2) + 1/math.Exp2(1) + 1/math.Exp2(2),
+		},
+	},
+	{
+		g: []set{
+			A: linksTo(B, C, D, E),
+			B: linksTo(C, D, E),
+			C: linksTo(D, E),
+			D: linksTo(E),
+			E: nil,
+		},
+
+		farness: map[int]float64{
+			A: 1 + 1 + 1 + 1,
+			B: 1 + 1 + 1 + 1,
+			C: 1 + 1 + 1 + 1,
+			D: 1 + 1 + 1 + 1,
+			E: 1 + 1 + 1 + 1,
+		},
+		harmonic: map[int]float64{
+			A: 1 + 1 + 1 + 1,
+			B: 1 + 1 + 1 + 1,
+			C: 1 + 1 + 1 + 1,
+			D: 1 + 1 + 1 + 1,
+			E: 1 + 1 + 1 + 1,
+		},
+		residual: map[int]float64{
+			A: 1/math.Exp2(1) + 1/math.Exp2(1) + 1/math.Exp2(1) + 1/math.Exp2(1),
+			B: 1/math.Exp2(1) + 1/math.Exp2(1) + 1/math.Exp2(1) + 1/math.Exp2(1),
+			C: 1/math.Exp2(1) + 1/math.Exp2(1) + 1/math.Exp2(1) + 1/math.Exp2(1),
+			D: 1/math.Exp2(1) + 1/math.Exp2(1) + 1/math.Exp2(1) + 1/math.Exp2(1),
+			E: 1/math.Exp2(1) + 1/math.Exp2(1) + 1/math.Exp2(1) + 1/math.Exp2(1),
+		},
+	},
+}
+
+func TestDistanceCentralityUndirected(t *testing.T) {
+	const tol = 1e-12
+	prec := 1 - int(math.Log10(tol))
+
+	for i, test := range undirectedCentralityTests {
+		g := concrete.NewGraph()
+		for u, e := range test.g {
+			if !g.NodeExists(concrete.Node(u)) {
+				g.AddNode(concrete.Node(u))
+			}
+			for v := range e {
+				if !g.NodeExists(concrete.Node(v)) {
+					g.AddNode(concrete.Node(v))
+				}
+				g.AddUndirectedEdge(concrete.Edge{H: concrete.Node(u), T: concrete.Node(v)}, 1)
+			}
+		}
+		p, ok := search.FloydWarshall(g, nil)
+		if !ok {
+			t.Errorf("unexpected negative cycle in test %d", i)
+			continue
+		}
+
+		var got map[int]float64
+
+		got = Closeness(g, p)
+		for n := range test.g {
+			if !floats.EqualWithinAbsOrRel(got[n], 1/test.farness[n], tol, tol) {
+				want := make(map[int]float64)
+				for n, v := range test.farness {
+					want[n] = 1 / v
+				}
+				t.Errorf("unexpected closeness centrality for test %d:\ngot: %v\nwant:%v",
+					i, orderedFloats(got, prec), orderedFloats(want, prec))
+				break
+			}
+		}
+
+		got = Farness(g, p)
+		for n := range test.g {
+			if !floats.EqualWithinAbsOrRel(got[n], test.farness[n], tol, tol) {
+				t.Errorf("unexpected farness for test %d:\ngot: %v\nwant:%v",
+					i, orderedFloats(got, prec), orderedFloats(test.farness, prec))
+				break
+			}
+		}
+
+		got = Harmonic(g, p)
+		for n := range test.g {
+			if !floats.EqualWithinAbsOrRel(got[n], test.harmonic[n], tol, tol) {
+				t.Errorf("unexpected harmonic centrality for test %d:\ngot: %v\nwant:%v",
+					i, orderedFloats(got, prec), orderedFloats(test.harmonic, prec))
+				break
+			}
+		}
+
+		got = Residual(g, p)
+		for n := range test.g {
+			if !floats.EqualWithinAbsOrRel(got[n], test.residual[n], tol, tol) {
+				t.Errorf("unexpected residual closeness for test %d:\ngot: %v\nwant:%v",
+					i, orderedFloats(got, prec), orderedFloats(test.residual, prec))
+				break
+			}
+		}
+	}
+}
+
+var directedCentralityTests = []struct {
+	g []set
+
+	farness  map[int]float64
+	harmonic map[int]float64
+	residual map[int]float64
+}{
+	{
+		g: []set{
+			A: linksTo(B),
+			B: linksTo(C),
+			C: nil,
+		},
+
+		farness: map[int]float64{
+			A: 0,
+			B: 1,
+			C: 2 + 1,
+		},
+		harmonic: map[int]float64{
+			A: 0,
+			B: 1,
+			C: 1.0/2.0 + 1,
+		},
+		residual: map[int]float64{
+			A: 0,
+			B: 1 / math.Exp2(1),
+			C: 1/math.Exp2(2) + 1/math.Exp2(1),
+		},
+	},
+	{
+		g: []set{
+			A: linksTo(B),
+			B: linksTo(C),
+			C: linksTo(D),
+			D: linksTo(E),
+			E: nil,
+		},
+
+		farness: map[int]float64{
+			A: 0,
+			B: 1,
+			C: 2 + 1,
+			D: 3 + 2 + 1,
+			E: 4 + 3 + 2 + 1,
+		},
+		harmonic: map[int]float64{
+			A: 0,
+			B: 1,
+			C: 1.0/2.0 + 1,
+			D: 1.0/3.0 + 1.0/2.0 + 1,
+			E: 1.0/4.0 + 1.0/3.0 + 1.0/2.0 + 1,
+		},
+		residual: map[int]float64{
+			A: 0,
+			B: 1 / math.Exp2(1),
+			C: 1/math.Exp2(2) + 1/math.Exp2(1),
+			D: 1/math.Exp2(3) + 1/math.Exp2(2) + 1/math.Exp2(1),
+			E: 1/math.Exp2(4) + 1/math.Exp2(3) + 1/math.Exp2(2) + 1/math.Exp2(1),
+		},
+	},
+	{
+		g: []set{
+			A: linksTo(C),
+			B: linksTo(C),
+			C: nil,
+			D: linksTo(C),
+			E: linksTo(C),
+		},
+
+		farness: map[int]float64{
+			A: 0,
+			B: 0,
+			C: 1 + 1 + 1 + 1,
+			D: 0,
+			E: 0,
+		},
+		harmonic: map[int]float64{
+			A: 0,
+			B: 0,
+			C: 1 + 1 + 1 + 1,
+			D: 0,
+			E: 0,
+		},
+		residual: map[int]float64{
+			A: 0,
+			B: 0,
+			C: 1/math.Exp2(1) + 1/math.Exp2(1) + 1/math.Exp2(1) + 1/math.Exp2(1),
+			D: 0,
+			E: 0,
+		},
+	},
+	{
+		g: []set{
+			A: linksTo(B, C, D, E),
+			B: linksTo(C, D, E),
+			C: linksTo(D, E),
+			D: linksTo(E),
+			E: nil,
+		},
+
+		farness: map[int]float64{
+			A: 0,
+			B: 1,
+			C: 1 + 1,
+			D: 1 + 1 + 1,
+			E: 1 + 1 + 1 + 1,
+		},
+		harmonic: map[int]float64{
+			A: 0,
+			B: 1,
+			C: 1 + 1,
+			D: 1 + 1 + 1,
+			E: 1 + 1 + 1 + 1,
+		},
+		residual: map[int]float64{
+			A: 0,
+			B: 1 / math.Exp2(1),
+			C: 1/math.Exp2(1) + 1/math.Exp2(1),
+			D: 1/math.Exp2(1) + 1/math.Exp2(1) + 1/math.Exp2(1),
+			E: 1/math.Exp2(1) + 1/math.Exp2(1) + 1/math.Exp2(1) + 1/math.Exp2(1),
+		},
+	},
+}
+
+func TestDistanceCentralityDirected(t *testing.T) {
+	const tol = 1e-12
+	prec := 1 - int(math.Log10(tol))
+
+	for i, test := range directedCentralityTests {
+		g := concrete.NewDirectedGraph()
+		for u, e := range test.g {
+			if !g.NodeExists(concrete.Node(u)) {
+				g.AddNode(concrete.Node(u))
+			}
+			for v := range e {
+				if !g.NodeExists(concrete.Node(v)) {
+					g.AddNode(concrete.Node(v))
+				}
+				g.AddDirectedEdge(concrete.Edge{H: concrete.Node(u), T: concrete.Node(v)}, 1)
+			}
+		}
+		p, ok := search.FloydWarshall(g, nil)
+		if !ok {
+			t.Errorf("unexpected negative cycle in test %d", i)
+			continue
+		}
+
+		var got map[int]float64
+
+		got = Closeness(g, p)
+		for n := range test.g {
+			if !floats.EqualWithinAbsOrRel(got[n], 1/test.farness[n], tol, tol) {
+				want := make(map[int]float64)
+				for n, v := range test.farness {
+					want[n] = 1 / v
+				}
+				t.Errorf("unexpected closeness centrality for test %d:\ngot: %v\nwant:%v",
+					i, orderedFloats(got, prec), orderedFloats(want, prec))
+				break
+			}
+		}
+
+		got = Farness(g, p)
+		for n := range test.g {
+			if !floats.EqualWithinAbsOrRel(got[n], test.farness[n], tol, tol) {
+				t.Errorf("unexpected farness for test %d:\ngot: %v\nwant:%v",
+					i, orderedFloats(got, prec), orderedFloats(test.farness, prec))
+				break
+			}
+		}
+
+		got = Harmonic(g, p)
+		for n := range test.g {
+			if !floats.EqualWithinAbsOrRel(got[n], test.harmonic[n], tol, tol) {
+				t.Errorf("unexpected harmonic centrality for test %d:\ngot: %v\nwant:%v",
+					i, orderedFloats(got, prec), orderedFloats(test.harmonic, prec))
+				break
+			}
+		}
+
+		got = Residual(g, p)
+		for n := range test.g {
+			if !floats.EqualWithinAbsOrRel(got[n], test.residual[n], tol, tol) {
+				t.Errorf("unexpected residual closeness for test %d:\ngot: %v\nwant:%v",
+					i, orderedFloats(got, prec), orderedFloats(test.residual, prec))
+				break
+			}
+		}
+	}
+}


### PR DESCRIPTION
This brings the general case for betweenness (though see below) and various centrality measures.

Currently we perform poorly for sparse graphs since we use FloydWarshal's algorithm to find shortest paths. One approach to address this would be for the functions here that take a search.ShortestPaths to take an equivalent interface (or a reduced interface for the centrality measures that only need weights) and then make search.Johnson return a type that satisfies this instead of a pair of maps. I don't want to do this because although it is an easy solution for the centrality measures it will give incorrect results for betweenness when there are non-unique shortest paths; the current implementation of Dijkstra's algorithm in search does not report more than one shortest path. So I plan to reimplement a Dijkstra's algorithm that does this, keeping the results in a search.ShortestPaths, and then call this from search.Johnson. I am not sure that I will export this implementation since the usual use case for Dijkstra is to find a single shortest path and the overhead for keeping all paths is non-trivial. Maybe we provide both.

Thoughts?

Whichever we do, I will generate both Dijkstra implementations from a template to keep them in sync except for the path retention.

Additional tests are probably needed for the weighted cases, but they can come later. Manually validating these is painful.

@vladimir-ch PTAL