### PR TITLE
{graph,concrete}: make node ID collision be a panic

### DIFF
--- a/concrete/mutablegr.go
+++ b/concrete/mutablegr.go
@@ -5,6 +5,8 @@
 package concrete
 
 import (
+	"fmt"
+
 	"github.com/gonum/graph"
 )
 
@@ -91,6 +93,9 @@ func (g *Graph) NewNode() graph.Node {
 }
 
 func (g *Graph) AddNode(n graph.Node) {
+	if _, exists := g.nodeMap[n.ID()]; exists {
+		panic(fmt.Sprintf("concrete: node ID collision: %d", n.ID()))
+	}
 	g.nodeMap[n.ID()] = n
 	g.neighbors[n.ID()] = make(map[int]WeightedEdge)
 

--- a/concrete/mutdir.go
+++ b/concrete/mutdir.go
@@ -5,6 +5,8 @@
 package concrete
 
 import (
+	"fmt"
+
 	"github.com/gonum/graph"
 )
 
@@ -63,6 +65,9 @@ func (g *DirectedGraph) NewNode() graph.Node {
 // Adds a node to the graph. Implementation note: if you add a node close to or at
 // the max int on your machine NewNode will become slower.
 func (g *DirectedGraph) AddNode(n graph.Node) {
+	if _, exists := g.nodeMap[n.ID()]; exists {
+		panic(fmt.Sprintf("concrete: node ID collision: %d", n.ID()))
+	}
 	g.nodeMap[n.ID()] = n
 	g.successors[n.ID()] = make(map[int]WeightedEdge)
 	g.predecessors[n.ID()] = make(map[int]WeightedEdge)

--- a/graph.go
+++ b/graph.go
@@ -131,8 +131,8 @@ type Mutable interface {
 	// NewNode returns a node with a unique arbitrary ID.
 	NewNode() Node
 
-	// Adds a node to the graph. If this is called multiple times for the same ID, the newer node
-	// overwrites the old one.
+	// Adds a node to the graph. AddNode panics if
+	// the added node ID matches an existing node ID.
 	AddNode(Node)
 
 	// RemoveNode removes a node from the graph, as well as any edges

--- a/network/betweenness_test.go
+++ b/network/betweenness_test.go
@@ -121,13 +121,11 @@ func TestBetweenness(t *testing.T) {
 	for i, test := range betweennessTests {
 		g := concrete.NewGraph()
 		for u, e := range test.g {
+			// Add nodes that are not defined by an edge.
 			if !g.NodeExists(concrete.Node(u)) {
 				g.AddNode(concrete.Node(u))
 			}
 			for v := range e {
-				if !g.NodeExists(concrete.Node(v)) {
-					g.AddNode(concrete.Node(v))
-				}
 				g.AddUndirectedEdge(concrete.Edge{F: concrete.Node(u), T: concrete.Node(v)}, 0)
 			}
 		}
@@ -152,13 +150,11 @@ func TestBetweennessWeighted(t *testing.T) {
 	for i, test := range betweennessTests {
 		g := concrete.NewGraph()
 		for u, e := range test.g {
+			// Add nodes that are not defined by an edge.
 			if !g.NodeExists(concrete.Node(u)) {
 				g.AddNode(concrete.Node(u))
 			}
 			for v := range e {
-				if !g.NodeExists(concrete.Node(v)) {
-					g.AddNode(concrete.Node(v))
-				}
 				g.AddUndirectedEdge(concrete.Edge{F: concrete.Node(u), T: concrete.Node(v)}, 1)
 			}
 		}

--- a/network/distance_test.go
+++ b/network/distance_test.go
@@ -145,13 +145,11 @@ func TestDistanceCentralityUndirected(t *testing.T) {
 	for i, test := range undirectedCentralityTests {
 		g := concrete.NewGraph()
 		for u, e := range test.g {
+			// Add nodes that are not defined by an edge.
 			if !g.NodeExists(concrete.Node(u)) {
 				g.AddNode(concrete.Node(u))
 			}
 			for v := range e {
-				if !g.NodeExists(concrete.Node(v)) {
-					g.AddNode(concrete.Node(v))
-				}
 				g.AddUndirectedEdge(concrete.Edge{F: concrete.Node(u), T: concrete.Node(v)}, 1)
 			}
 		}
@@ -337,13 +335,11 @@ func TestDistanceCentralityDirected(t *testing.T) {
 	for i, test := range directedCentralityTests {
 		g := concrete.NewDirectedGraph()
 		for u, e := range test.g {
+			// Add nodes that are not defined by an edge.
 			if !g.NodeExists(concrete.Node(u)) {
 				g.AddNode(concrete.Node(u))
 			}
 			for v := range e {
-				if !g.NodeExists(concrete.Node(v)) {
-					g.AddNode(concrete.Node(v))
-				}
 				g.AddDirectedEdge(concrete.Edge{F: concrete.Node(u), T: concrete.Node(v)}, 1)
 			}
 		}

--- a/network/hits_test.go
+++ b/network/hits_test.go
@@ -45,13 +45,11 @@ func TestHITS(t *testing.T) {
 	for i, test := range hitsTests {
 		g := concrete.NewDirectedGraph()
 		for u, e := range test.g {
+			// Add nodes that are not defined by an edge.
 			if !g.NodeExists(concrete.Node(u)) {
 				g.AddNode(concrete.Node(u))
 			}
 			for v := range e {
-				if !g.NodeExists(concrete.Node(v)) {
-					g.AddNode(concrete.Node(v))
-				}
 				g.AddDirectedEdge(concrete.Edge{F: concrete.Node(u), T: concrete.Node(v)}, 0)
 			}
 		}

--- a/network/page_test.go
+++ b/network/page_test.go
@@ -83,13 +83,11 @@ func TestPageRank(t *testing.T) {
 	for i, test := range pageRankTests {
 		g := concrete.NewDirectedGraph()
 		for u, e := range test.g {
+			// Add nodes that are not defined by an edge.
 			if !g.NodeExists(concrete.Node(u)) {
 				g.AddNode(concrete.Node(u))
 			}
 			for v := range e {
-				if !g.NodeExists(concrete.Node(v)) {
-					g.AddNode(concrete.Node(v))
-				}
 				g.AddDirectedEdge(concrete.Edge{F: concrete.Node(u), T: concrete.Node(v)}, 0)
 			}
 		}
@@ -109,13 +107,11 @@ func TestPageRankSparse(t *testing.T) {
 	for i, test := range pageRankTests {
 		g := concrete.NewDirectedGraph()
 		for u, e := range test.g {
+			// Add nodes that are not defined by an edge.
 			if !g.NodeExists(concrete.Node(u)) {
 				g.AddNode(concrete.Node(u))
 			}
 			for v := range e {
-				if !g.NodeExists(concrete.Node(v)) {
-					g.AddNode(concrete.Node(v))
-				}
 				g.AddDirectedEdge(concrete.Edge{F: concrete.Node(u), T: concrete.Node(v)}, 0)
 			}
 		}

--- a/search/johnson_cycles_test.go
+++ b/search/johnson_cycles_test.go
@@ -89,13 +89,11 @@ func TestCyclesIn(t *testing.T) {
 		g := concrete.NewDirectedGraph()
 		g.AddNode(concrete.Node(-10)) // Make sure we test graphs with sparse IDs.
 		for u, e := range test.g {
+			// Add nodes that are not defined by an edge.
 			if !g.NodeExists(concrete.Node(u)) {
 				g.AddNode(concrete.Node(u))
 			}
 			for v := range e {
-				if !g.NodeExists(concrete.Node(v)) {
-					g.AddNode(concrete.Node(v))
-				}
 				g.AddDirectedEdge(concrete.Edge{F: concrete.Node(u), T: concrete.Node(v)}, 0)
 			}
 		}

--- a/search/search_test.go
+++ b/search/search_test.go
@@ -362,13 +362,11 @@ func TestTarjanSCC(t *testing.T) {
 	for i, test := range tarjanTests {
 		g := concrete.NewDirectedGraph()
 		for u, e := range test.g {
+			// Add nodes that are not defined by an edge.
 			if !g.NodeExists(concrete.Node(u)) {
 				g.AddNode(concrete.Node(u))
 			}
 			for v := range e {
-				if !g.NodeExists(concrete.Node(v)) {
-					g.AddNode(concrete.Node(v))
-				}
 				g.AddDirectedEdge(concrete.Edge{F: concrete.Node(u), T: concrete.Node(v)}, 0)
 			}
 		}
@@ -460,13 +458,11 @@ func TestVertexOrdering(t *testing.T) {
 	for i, test := range vOrderTests {
 		g := concrete.NewGraph()
 		for u, e := range test.g {
+			// Add nodes that are not defined by an edge.
 			if !g.NodeExists(concrete.Node(u)) {
 				g.AddNode(concrete.Node(u))
 			}
 			for v := range e {
-				if !g.NodeExists(concrete.Node(v)) {
-					g.AddNode(concrete.Node(v))
-				}
 				g.AddUndirectedEdge(concrete.Edge{F: concrete.Node(u), T: concrete.Node(v)}, 0)
 			}
 		}
@@ -547,13 +543,11 @@ func TestBronKerbosch(t *testing.T) {
 	for i, test := range bronKerboschTests {
 		g := concrete.NewGraph()
 		for u, e := range test.g {
+			// Add nodes that are not defined by an edge.
 			if !g.NodeExists(concrete.Node(u)) {
 				g.AddNode(concrete.Node(u))
 			}
 			for v := range e {
-				if !g.NodeExists(concrete.Node(v)) {
-					g.AddNode(concrete.Node(v))
-				}
 				g.AddUndirectedEdge(concrete.Edge{F: concrete.Node(u), T: concrete.Node(v)}, 0)
 			}
 		}
@@ -599,13 +593,11 @@ func TestConnectedComponents(t *testing.T) {
 			}
 
 			for u, e := range test.g {
+				// Add nodes that are not defined by an edge.
 				if !g.NodeExists(concrete.Node(u)) {
 					g.(graph.Mutable).AddNode(concrete.Node(u))
 				}
 				for v := range e {
-					if !g.NodeExists(concrete.Node(v)) {
-						g.(graph.Mutable).AddNode(concrete.Node(v))
-					}
 					switch g := g.(type) {
 					case graph.MutableDirectedGraph:
 						g.AddDirectedEdge(concrete.Edge{F: concrete.Node(u), T: concrete.Node(v)}, 0)

--- a/traverse/traverse_test.go
+++ b/traverse/traverse_test.go
@@ -135,13 +135,11 @@ func TestBreadthFirst(t *testing.T) {
 	for i, test := range breadthFirstTests {
 		g := concrete.NewGraph()
 		for u, e := range test.g {
+			// Add nodes that are not defined by an edge.
 			if !g.NodeExists(concrete.Node(u)) {
 				g.AddNode(concrete.Node(u))
 			}
 			for v := range e {
-				if !g.NodeExists(concrete.Node(v)) {
-					g.AddNode(concrete.Node(v))
-				}
 				g.AddUndirectedEdge(concrete.Edge{F: concrete.Node(u), T: concrete.Node(v)}, 0)
 			}
 		}
@@ -225,13 +223,11 @@ func TestDepthFirst(t *testing.T) {
 	for i, test := range depthFirstTests {
 		g := concrete.NewGraph()
 		for u, e := range test.g {
+			// Add nodes that are not defined by an edge.
 			if !g.NodeExists(concrete.Node(u)) {
 				g.AddNode(concrete.Node(u))
 			}
 			for v := range e {
-				if !g.NodeExists(concrete.Node(v)) {
-					g.AddNode(concrete.Node(v))
-				}
 				g.AddUndirectedEdge(concrete.Edge{F: concrete.Node(u), T: concrete.Node(v)}, 0)
 			}
 		}
@@ -295,13 +291,11 @@ func TestWalkAll(t *testing.T) {
 			}
 
 			for u, e := range test.g {
+				// Add nodes that are not defined by an edge.
 				if !g.NodeExists(concrete.Node(u)) {
 					g.(graph.Mutable).AddNode(concrete.Node(u))
 				}
 				for v := range e {
-					if !g.NodeExists(concrete.Node(v)) {
-						g.(graph.Mutable).AddNode(concrete.Node(v))
-					}
 					switch g := g.(type) {
 					case graph.MutableDirectedGraph:
 						g.AddDirectedEdge(concrete.Edge{F: concrete.Node(u), T: concrete.Node(v)}, 0)


### PR DESCRIPTION
This is consistent with our approaches to flexibility in matrix and blas. We don't allow potentially unsafe things to go unnoticed.

@gonum/developers PTAL

