### PR TITLE
graph: split mutation API into smaller interfaces

### DIFF
--- a/path/dynamic/dstarlite.go
+++ b/path/dynamic/dstarlite.go
@@ -33,7 +33,7 @@ type DStarLite struct {
 // WorldModel is a mutable weighted directed graph that returns nodes identified
 // by id number.
 type WorldModel interface {
-	graph.MutableDirected
+	graph.DirectedBuilder
 	graph.Weighter
 	Node(id int) graph.Node
 }

--- a/path/internal/testgraphs/shortest.go
+++ b/path/internal/testgraphs/shortest.go
@@ -25,7 +25,7 @@ func init() {
 // dynamic shortest path routine in path/dynamic: DStarLite.
 var ShortestPathTests = []struct {
 	Name              string
-	Graph             func() graph.Mutable
+	Graph             func() graph.EdgeSetter
 	Edges             []simple.Edge
 	HasNegativeWeight bool
 	HasNegativeCycle  bool
@@ -40,7 +40,7 @@ var ShortestPathTests = []struct {
 	// Positive weighted graphs.
 	{
 		Name:  "empty directed",
-		Graph: func() graph.Mutable { return simple.NewDirectedGraph(0, math.Inf(1)) },
+		Graph: func() graph.EdgeSetter { return simple.NewDirectedGraph(0, math.Inf(1)) },
 
 		Query:  simple.Edge{F: simple.Node(0), T: simple.Node(1)},
 		Weight: math.Inf(1),
@@ -49,7 +49,7 @@ var ShortestPathTests = []struct {
 	},
 	{
 		Name:  "empty undirected",
-		Graph: func() graph.Mutable { return simple.NewUndirectedGraph(0, math.Inf(1)) },
+		Graph: func() graph.EdgeSetter { return simple.NewUndirectedGraph(0, math.Inf(1)) },
 
 		Query:  simple.Edge{F: simple.Node(0), T: simple.Node(1)},
 		Weight: math.Inf(1),
@@ -58,7 +58,7 @@ var ShortestPathTests = []struct {
 	},
 	{
 		Name:  "one edge directed",
-		Graph: func() graph.Mutable { return simple.NewDirectedGraph(0, math.Inf(1)) },
+		Graph: func() graph.EdgeSetter { return simple.NewDirectedGraph(0, math.Inf(1)) },
 		Edges: []simple.Edge{
 			{F: simple.Node(0), T: simple.Node(1), W: 1},
 		},
@@ -74,7 +74,7 @@ var ShortestPathTests = []struct {
 	},
 	{
 		Name:  "one edge self directed",
-		Graph: func() graph.Mutable { return simple.NewDirectedGraph(0, math.Inf(1)) },
+		Graph: func() graph.EdgeSetter { return simple.NewDirectedGraph(0, math.Inf(1)) },
 		Edges: []simple.Edge{
 			{F: simple.Node(0), T: simple.Node(1), W: 1},
 		},
@@ -90,7 +90,7 @@ var ShortestPathTests = []struct {
 	},
 	{
 		Name:  "one edge undirected",
-		Graph: func() graph.Mutable { return simple.NewUndirectedGraph(0, math.Inf(1)) },
+		Graph: func() graph.EdgeSetter { return simple.NewUndirectedGraph(0, math.Inf(1)) },
 		Edges: []simple.Edge{
 			{F: simple.Node(0), T: simple.Node(1), W: 1},
 		},
@@ -106,7 +106,7 @@ var ShortestPathTests = []struct {
 	},
 	{
 		Name:  "two paths directed",
-		Graph: func() graph.Mutable { return simple.NewDirectedGraph(0, math.Inf(1)) },
+		Graph: func() graph.EdgeSetter { return simple.NewDirectedGraph(0, math.Inf(1)) },
 		Edges: []simple.Edge{
 			{F: simple.Node(0), T: simple.Node(2), W: 2},
 			{F: simple.Node(0), T: simple.Node(1), W: 1},
@@ -125,7 +125,7 @@ var ShortestPathTests = []struct {
 	},
 	{
 		Name:  "two paths undirected",
-		Graph: func() graph.Mutable { return simple.NewUndirectedGraph(0, math.Inf(1)) },
+		Graph: func() graph.EdgeSetter { return simple.NewUndirectedGraph(0, math.Inf(1)) },
 		Edges: []simple.Edge{
 			{F: simple.Node(0), T: simple.Node(2), W: 2},
 			{F: simple.Node(0), T: simple.Node(1), W: 1},
@@ -144,7 +144,7 @@ var ShortestPathTests = []struct {
 	},
 	{
 		Name:  "confounding paths directed",
-		Graph: func() graph.Mutable { return simple.NewDirectedGraph(0, math.Inf(1)) },
+		Graph: func() graph.EdgeSetter { return simple.NewDirectedGraph(0, math.Inf(1)) },
 		Edges: []simple.Edge{
 			// Add a path from 0->5 of weight 4
 			{F: simple.Node(0), T: simple.Node(1), W: 1},
@@ -178,7 +178,7 @@ var ShortestPathTests = []struct {
 	},
 	{
 		Name:  "confounding paths undirected",
-		Graph: func() graph.Mutable { return simple.NewUndirectedGraph(0, math.Inf(1)) },
+		Graph: func() graph.EdgeSetter { return simple.NewUndirectedGraph(0, math.Inf(1)) },
 		Edges: []simple.Edge{
 			// Add a path from 0->5 of weight 4
 			{F: simple.Node(0), T: simple.Node(1), W: 1},
@@ -212,7 +212,7 @@ var ShortestPathTests = []struct {
 	},
 	{
 		Name:  "confounding paths directed 2-step",
-		Graph: func() graph.Mutable { return simple.NewDirectedGraph(0, math.Inf(1)) },
+		Graph: func() graph.EdgeSetter { return simple.NewDirectedGraph(0, math.Inf(1)) },
 		Edges: []simple.Edge{
 			// Add a path from 0->5 of weight 4
 			{F: simple.Node(0), T: simple.Node(1), W: 1},
@@ -247,7 +247,7 @@ var ShortestPathTests = []struct {
 	},
 	{
 		Name:  "confounding paths undirected 2-step",
-		Graph: func() graph.Mutable { return simple.NewUndirectedGraph(0, math.Inf(1)) },
+		Graph: func() graph.EdgeSetter { return simple.NewUndirectedGraph(0, math.Inf(1)) },
 		Edges: []simple.Edge{
 			// Add a path from 0->5 of weight 4
 			{F: simple.Node(0), T: simple.Node(1), W: 1},
@@ -282,7 +282,7 @@ var ShortestPathTests = []struct {
 	},
 	{
 		Name:  "zero-weight cycle directed",
-		Graph: func() graph.Mutable { return simple.NewDirectedGraph(0, math.Inf(1)) },
+		Graph: func() graph.EdgeSetter { return simple.NewDirectedGraph(0, math.Inf(1)) },
 		Edges: []simple.Edge{
 			// Add a path from 0->4 of weight 4
 			{F: simple.Node(0), T: simple.Node(1), W: 1},
@@ -306,7 +306,7 @@ var ShortestPathTests = []struct {
 	},
 	{
 		Name:  "zero-weight cycle^2 directed",
-		Graph: func() graph.Mutable { return simple.NewDirectedGraph(0, math.Inf(1)) },
+		Graph: func() graph.EdgeSetter { return simple.NewDirectedGraph(0, math.Inf(1)) },
 		Edges: []simple.Edge{
 			// Add a path from 0->4 of weight 4
 			{F: simple.Node(0), T: simple.Node(1), W: 1},
@@ -333,7 +333,7 @@ var ShortestPathTests = []struct {
 	},
 	{
 		Name:  "zero-weight cycle^2 confounding directed",
-		Graph: func() graph.Mutable { return simple.NewDirectedGraph(0, math.Inf(1)) },
+		Graph: func() graph.EdgeSetter { return simple.NewDirectedGraph(0, math.Inf(1)) },
 		Edges: []simple.Edge{
 			// Add a path from 0->4 of weight 4
 			{F: simple.Node(0), T: simple.Node(1), W: 1},
@@ -363,7 +363,7 @@ var ShortestPathTests = []struct {
 	},
 	{
 		Name:  "zero-weight cycle^3 directed",
-		Graph: func() graph.Mutable { return simple.NewDirectedGraph(0, math.Inf(1)) },
+		Graph: func() graph.EdgeSetter { return simple.NewDirectedGraph(0, math.Inf(1)) },
 		Edges: []simple.Edge{
 			// Add a path from 0->4 of weight 4
 			{F: simple.Node(0), T: simple.Node(1), W: 1},
@@ -393,7 +393,7 @@ var ShortestPathTests = []struct {
 	},
 	{
 		Name:  "zero-weight 3·cycle^2 confounding directed",
-		Graph: func() graph.Mutable { return simple.NewDirectedGraph(0, math.Inf(1)) },
+		Graph: func() graph.EdgeSetter { return simple.NewDirectedGraph(0, math.Inf(1)) },
 		Edges: []simple.Edge{
 			// Add a path from 0->4 of weight 4
 			{F: simple.Node(0), T: simple.Node(1), W: 1},
@@ -429,7 +429,7 @@ var ShortestPathTests = []struct {
 	},
 	{
 		Name:  "zero-weight reversed 3·cycle^2 confounding directed",
-		Graph: func() graph.Mutable { return simple.NewDirectedGraph(0, math.Inf(1)) },
+		Graph: func() graph.EdgeSetter { return simple.NewDirectedGraph(0, math.Inf(1)) },
 		Edges: []simple.Edge{
 			// Add a path from 0->4 of weight 4
 			{F: simple.Node(0), T: simple.Node(1), W: 1},
@@ -465,7 +465,7 @@ var ShortestPathTests = []struct {
 	},
 	{
 		Name:  "zero-weight |V|·cycle^(n/|V|) directed",
-		Graph: func() graph.Mutable { return simple.NewDirectedGraph(0, math.Inf(1)) },
+		Graph: func() graph.EdgeSetter { return simple.NewDirectedGraph(0, math.Inf(1)) },
 		Edges: func() []simple.Edge {
 			e := []simple.Edge{
 				// Add a path from 0->4 of weight 4
@@ -498,7 +498,7 @@ var ShortestPathTests = []struct {
 	},
 	{
 		Name:  "zero-weight n·cycle directed",
-		Graph: func() graph.Mutable { return simple.NewDirectedGraph(0, math.Inf(1)) },
+		Graph: func() graph.EdgeSetter { return simple.NewDirectedGraph(0, math.Inf(1)) },
 		Edges: func() []simple.Edge {
 			e := []simple.Edge{
 				// Add a path from 0->4 of weight 4
@@ -531,7 +531,7 @@ var ShortestPathTests = []struct {
 	},
 	{
 		Name:  "zero-weight bi-directional tree with single exit directed",
-		Graph: func() graph.Mutable { return simple.NewDirectedGraph(0, math.Inf(1)) },
+		Graph: func() graph.EdgeSetter { return simple.NewDirectedGraph(0, math.Inf(1)) },
 		Edges: func() []simple.Edge {
 			e := []simple.Edge{
 				// Add a path from 0->4 of weight 4
@@ -579,7 +579,7 @@ var ShortestPathTests = []struct {
 	// Negative weighted graphs.
 	{
 		Name:  "one edge directed negative",
-		Graph: func() graph.Mutable { return simple.NewDirectedGraph(0, math.Inf(1)) },
+		Graph: func() graph.EdgeSetter { return simple.NewDirectedGraph(0, math.Inf(1)) },
 		Edges: []simple.Edge{
 			{F: simple.Node(0), T: simple.Node(1), W: -1},
 		},
@@ -596,7 +596,7 @@ var ShortestPathTests = []struct {
 	},
 	{
 		Name:  "one edge undirected negative",
-		Graph: func() graph.Mutable { return simple.NewUndirectedGraph(0, math.Inf(1)) },
+		Graph: func() graph.EdgeSetter { return simple.NewUndirectedGraph(0, math.Inf(1)) },
 		Edges: []simple.Edge{
 			{F: simple.Node(0), T: simple.Node(1), W: -1},
 		},
@@ -607,7 +607,7 @@ var ShortestPathTests = []struct {
 	},
 	{
 		Name:  "wp graph negative", // http://en.wikipedia.org/w/index.php?title=Johnson%27s_algorithm&oldid=564595231
-		Graph: func() graph.Mutable { return simple.NewDirectedGraph(0, math.Inf(1)) },
+		Graph: func() graph.EdgeSetter { return simple.NewDirectedGraph(0, math.Inf(1)) },
 		Edges: []simple.Edge{
 			{F: simple.Node('w'), T: simple.Node('z'), W: 2},
 			{F: simple.Node('x'), T: simple.Node('w'), W: 6},
@@ -630,7 +630,7 @@ var ShortestPathTests = []struct {
 	},
 	{
 		Name:  "roughgarden negative",
-		Graph: func() graph.Mutable { return simple.NewDirectedGraph(0, math.Inf(1)) },
+		Graph: func() graph.EdgeSetter { return simple.NewDirectedGraph(0, math.Inf(1)) },
 		Edges: []simple.Edge{
 			{F: simple.Node('a'), T: simple.Node('b'), W: -2},
 			{F: simple.Node('b'), T: simple.Node('c'), W: -1},

--- a/path/spanning_tree.go
+++ b/path/spanning_tree.go
@@ -25,7 +25,7 @@ type UndirectedWeighter interface {
 // first. The weight of the minimum spanning tree is returned. If g is not connected,
 // a minimum spanning forest will be constructed in dst and the sum of minimum
 // spanning tree weights will be returned.
-func Prim(dst graph.MutableUndirected, g UndirectedWeighter) float64 {
+func Prim(dst graph.UndirectedBuilder, g UndirectedWeighter) float64 {
 	nodes := g.Nodes()
 	if len(nodes) == 0 {
 		return 0
@@ -145,7 +145,7 @@ type UndirectedWeightLister interface {
 // first. The weight of the minimum spanning tree is returned. If g is not connected,
 // a minimum spanning forest will be constructed in dst and the sum of minimum
 // spanning tree weights will be returned.
-func Kruskal(dst graph.MutableUndirected, g UndirectedWeightLister) float64 {
+func Kruskal(dst graph.UndirectedBuilder, g UndirectedWeightLister) float64 {
 	edges := g.Edges()
 	ascend := make([]simple.Edge, 0, len(edges))
 	for _, e := range edges {

--- a/path/spanning_tree_test.go
+++ b/path/spanning_tree_test.go
@@ -26,7 +26,7 @@ func init() {
 }
 
 type spanningGraph interface {
-	graph.MutableUndirected
+	graph.UndirectedBuilder
 	graph.Weighter
 	Edges() []graph.Edge
 }
@@ -240,7 +240,7 @@ var spanningTreeTests = []struct {
 	},
 }
 
-func testMinumumSpanning(mst func(dst graph.MutableUndirected, g spanningGraph) float64, t *testing.T) {
+func testMinumumSpanning(mst func(dst graph.UndirectedBuilder, g spanningGraph) float64, t *testing.T) {
 	for _, test := range spanningTreeTests {
 		g := test.graph()
 		for _, e := range test.edges {
@@ -282,13 +282,13 @@ func testMinumumSpanning(mst func(dst graph.MutableUndirected, g spanningGraph) 
 }
 
 func TestKruskal(t *testing.T) {
-	testMinumumSpanning(func(dst graph.MutableUndirected, g spanningGraph) float64 {
+	testMinumumSpanning(func(dst graph.UndirectedBuilder, g spanningGraph) float64 {
 		return Kruskal(dst, g)
 	}, t)
 }
 
 func TestPrim(t *testing.T) {
-	testMinumumSpanning(func(dst graph.MutableUndirected, g spanningGraph) float64 {
+	testMinumumSpanning(func(dst graph.UndirectedBuilder, g spanningGraph) float64 {
 		return Prim(dst, g)
 	}, t)
 }

--- a/simple/undirected_test.go
+++ b/simple/undirected_test.go
@@ -14,7 +14,7 @@ import (
 var _ graph.Graph = (*UndirectedGraph)(nil)
 
 func TestAssertMutableNotDirected(t *testing.T) {
-	var g graph.MutableUndirected = NewUndirectedGraph(0, math.Inf(1))
+	var g graph.UndirectedBuilder = NewUndirectedGraph(0, math.Inf(1))
 	if _, ok := g.(graph.Directed); ok {
 		t.Fatal("Graph is directed, but a MutableGraph cannot safely be directed!")
 	}


### PR DESCRIPTION
graph.Mutable was previously used primarily to add nodes and edges, so
it is not sensible to require that edge and node deletion also be
implemented - there are add-only graph implementations that gain
possible optimisations by this change.

This change also potentially paves the way for multigraph addition with
an EdgeAdder interface.

Also drop the fictional distinction between the two Copy functions.

@vladimir-ch Please take a look - this was a much smaller change than I was expecting.