### PR TITLE
all: rename HasEdge -> HasEdgeBetween

### DIFF
--- a/ex/fdpclust/gn.go
+++ b/ex/fdpclust/gn.go
@@ -187,7 +187,7 @@ func (g *GraphNode) findNeighbors(n graph.Node, visited map[int]struct{}) []grap
 	return nil
 }
 
-func (g *GraphNode) HasEdge(u, v graph.Node) bool {
+func (g *GraphNode) HasEdgeBetween(u, v graph.Node) bool {
 	return g.EdgeBetween(u, v) != nil
 }
 

--- a/graph.go
+++ b/graph.go
@@ -30,9 +30,9 @@ type Graph interface {
 	// from the given node.
 	From(Node) []Node
 
-	// HasEdge returns whether an edge exists between
+	// HasEdgeBeteen returns whether an edge exists between
 	// nodes x and y without considering direction.
-	HasEdge(x, y Node) bool
+	HasEdgeBetween(x, y Node) bool
 
 	// Edge returns the edge from u to v if such an edge
 	// exists and nil otherwise. The node v must be directly

--- a/graphs/gen/batagelj_brandes.go
+++ b/graphs/gen/batagelj_brandes.go
@@ -90,7 +90,7 @@ func Gnm(dst GraphBuilder, n, m int, src *rand.Rand) error {
 		return nil
 	}
 
-	hasEdge := dst.HasEdge
+	hasEdge := dst.HasEdgeBetween
 	d, isDirected := dst.(graph.Directed)
 	if isDirected {
 		m /= 2
@@ -173,7 +173,7 @@ func SmallWorldsBB(dst GraphBuilder, n, d int, p float64, src *rand.Rand) error 
 		rndN = src.Intn
 	}
 
-	hasEdge := dst.HasEdge
+	hasEdge := dst.HasEdgeBetween
 	dg, isDirected := dst.(graph.Directed)
 	if isDirected {
 		hasEdge = dg.HasEdgeFromTo

--- a/graphs/gen/batagelj_brandes_test.go
+++ b/graphs/gen/batagelj_brandes_test.go
@@ -26,7 +26,7 @@ func (g *gnUndirected) SetEdge(e graph.Edge) {
 		return
 	case e.From().ID() > e.To().ID():
 		g.addBackwards = true
-	case g.UndirectedBuilder.HasEdge(e.From(), e.To()):
+	case g.UndirectedBuilder.HasEdgeBetween(e.From(), e.To()):
 		g.addMultipleEdge = true
 	}
 

--- a/graphs/gen/gen.go
+++ b/graphs/gen/gen.go
@@ -10,7 +10,7 @@ import "github.com/gonum/graph"
 // GraphBuilder is a graph that can have nodes and edges added.
 type GraphBuilder interface {
 	Has(graph.Node) bool
-	HasEdge(x, y graph.Node) bool
+	HasEdgeBetween(x, y graph.Node) bool
 	graph.Builder
 }
 

--- a/graphs/gen/holme_kim.go
+++ b/graphs/gen/holme_kim.go
@@ -69,7 +69,7 @@ func TunableClusteringScaleFree(dst graph.UndirectedBuilder, n, m int, p float64
 			if i != 0 && rnd() < p {
 				for _, w := range permute(dst.From(simple.Node(u)), rndN) {
 					wid := w.ID()
-					if wid == v || dst.HasEdge(w, simple.Node(v)) {
+					if wid == v || dst.HasEdgeBetween(w, simple.Node(v)) {
 						continue
 					}
 					dst.SetEdge(simple.Edge{F: w, T: simple.Node(v), W: 1})
@@ -86,7 +86,7 @@ func TunableClusteringScaleFree(dst graph.UndirectedBuilder, n, m int, p float64
 				if !ok {
 					return errors.New("gen: depleted distribution")
 				}
-				if u == v || dst.HasEdge(simple.Node(u), simple.Node(v)) {
+				if u == v || dst.HasEdgeBetween(simple.Node(u), simple.Node(v)) {
 					continue
 				}
 				dst.SetEdge(simple.Edge{F: simple.Node(u), T: simple.Node(v), W: 1})

--- a/graphs/gen/small_world.go
+++ b/graphs/gen/small_world.go
@@ -44,7 +44,7 @@ func NavigableSmallWorld(dst GraphBuilder, dims []int, p, q int, r float64, src 
 		}
 	}
 
-	hasEdge := dst.HasEdge
+	hasEdge := dst.HasEdgeBetween
 	d, isDirected := dst.(graph.Directed)
 	if isDirected {
 		hasEdge = d.HasEdgeFromTo

--- a/path/dynamic/dstarlite_test.go
+++ b/path/dynamic/dstarlite_test.go
@@ -402,18 +402,18 @@ var dynamicDStarLiteTests = []struct {
 			// Check we have a correctly modified representation.
 			for _, u := range l.Nodes() {
 				for _, v := range l.Nodes() {
-					if l.HasEdge(u, v) != l.Grid.HasEdge(u, v) {
+					if l.HasEdgeBetween(u, v) != l.Grid.HasEdgeBetween(u, v) {
 						ur, uc := l.RowCol(u.ID())
 						vr, vc := l.RowCol(v.ID())
 						if (ur == wallRow && uc == wallCol) || (vr == wallRow && vc == wallCol) {
-							if !l.HasEdge(u, v) {
+							if !l.HasEdgeBetween(u, v) {
 								panic(fmt.Sprintf("expected to believe edge between %v (%d,%d) and %v (%d,%d) is passable",
 									u, v, ur, uc, vr, vc))
 							}
 							continue
 						}
 						panic(fmt.Sprintf("disagreement about edge between %v (%d,%d) and %v (%d,%d): got:%t want:%t",
-							u, v, ur, uc, vr, vc, l.HasEdge(u, v), l.Grid.HasEdge(u, v)))
+							u, v, ur, uc, vr, vc, l.HasEdgeBetween(u, v), l.Grid.HasEdgeBetween(u, v)))
 					}
 				}
 			}

--- a/path/internal/grid.go
+++ b/path/internal/grid.go
@@ -171,7 +171,7 @@ func (g *Grid) From(u graph.Node) []graph.Node {
 	var to []graph.Node
 	for r := nr - 1; r <= nr+1; r++ {
 		for c := nc - 1; c <= nc+1; c++ {
-			if v := g.NodeAt(r, c); v != nil && g.HasEdge(u, v) {
+			if v := g.NodeAt(r, c); v != nil && g.HasEdgeBetween(u, v) {
 				to = append(to, v)
 			}
 		}
@@ -179,8 +179,8 @@ func (g *Grid) From(u graph.Node) []graph.Node {
 	return to
 }
 
-// HasEdge returns whether there is an edge between u and v.
-func (g *Grid) HasEdge(u, v graph.Node) bool {
+// HasEdgeBetween returns whether there is an edge between u and v.
+func (g *Grid) HasEdgeBetween(u, v graph.Node) bool {
 	if !g.HasOpen(u) || !g.HasOpen(v) || u.ID() == v.ID() {
 		return false
 	}
@@ -206,7 +206,7 @@ func (g *Grid) Edge(u, v graph.Node) graph.Edge {
 
 // EdgeBetween returns the edge between u and v.
 func (g *Grid) EdgeBetween(u, v graph.Node) graph.Edge {
-	if g.HasEdge(u, v) {
+	if g.HasEdgeBetween(u, v) {
 		if !g.AllowDiagonal || g.UnitEdgeWeight {
 			return simple.Edge{F: u, T: v, W: 1}
 		}
@@ -222,7 +222,7 @@ func (g *Grid) Weight(x, y graph.Node) (w float64, ok bool) {
 	if x.ID() == y.ID() {
 		return 0, true
 	}
-	if !g.HasEdge(x, y) {
+	if !g.HasEdgeBetween(x, y) {
 		return math.Inf(1), false
 	}
 	if e := g.EdgeBetween(x, y); e != nil {
@@ -264,7 +264,7 @@ func (g *Grid) Render(path []graph.Node) ([]byte, error) {
 	// We don't use topo.IsPathIn at the outset because we
 	// want to draw as much as possible before failing.
 	for i, n := range path {
-		if !g.Has(n) || (i != 0 && !g.HasEdge(path[i-1], n)) {
+		if !g.Has(n) || (i != 0 && !g.HasEdgeBetween(path[i-1], n)) {
 			id := n.ID()
 			if id >= 0 && id < len(g.open) {
 				r, c := g.RowCol(n.ID())

--- a/path/internal/limited.go
+++ b/path/internal/limited.go
@@ -175,7 +175,7 @@ func (l *LimitedVisionGrid) From(u graph.Node) []graph.Node {
 	var to []graph.Node
 	for r := nr - 1; r <= nr+1; r++ {
 		for c := nc - 1; c <= nc+1; c++ {
-			if v := l.NodeAt(r, c); v != nil && l.HasEdge(u, v) {
+			if v := l.NodeAt(r, c); v != nil && l.HasEdgeBetween(u, v) {
 				to = append(to, v)
 			}
 		}
@@ -183,8 +183,8 @@ func (l *LimitedVisionGrid) From(u graph.Node) []graph.Node {
 	return to
 }
 
-// HasEdge optimistically returns whether an edge is exists between u and v.
-func (l *LimitedVisionGrid) HasEdge(u, v graph.Node) bool {
+// HasEdgeBetween optimistically returns whether an edge is exists between u and v.
+func (l *LimitedVisionGrid) HasEdgeBetween(u, v graph.Node) bool {
 	if u.ID() == v.ID() {
 		return false
 	}
@@ -205,7 +205,7 @@ func (l *LimitedVisionGrid) HasEdge(u, v graph.Node) bool {
 
 	switch {
 	case uKnown && vKnown:
-		return l.Grid.HasEdge(u, v)
+		return l.Grid.HasEdgeBetween(u, v)
 	case uKnown:
 		return l.Grid.HasOpen(u)
 	case vKnown:
@@ -222,7 +222,7 @@ func (l *LimitedVisionGrid) Edge(u, v graph.Node) graph.Edge {
 
 // Edge optimistically returns the edge between u and v.
 func (l *LimitedVisionGrid) EdgeBetween(u, v graph.Node) graph.Edge {
-	if l.HasEdge(u, v) {
+	if l.HasEdgeBetween(u, v) {
 		if !l.Grid.AllowDiagonal || l.Grid.UnitEdgeWeight {
 			return simple.Edge{F: u, T: v, W: 1}
 		}
@@ -238,7 +238,7 @@ func (l *LimitedVisionGrid) Weight(x, y graph.Node) (w float64, ok bool) {
 	if x.ID() == y.ID() {
 		return 0, true
 	}
-	if !l.HasEdge(x, y) {
+	if !l.HasEdgeBetween(x, y) {
 		return math.Inf(1), false
 	}
 	if e := l.EdgeBetween(x, y); e != nil {
@@ -284,7 +284,7 @@ func (l *LimitedVisionGrid) Render(path []graph.Node) ([]byte, error) {
 	// We don't use topo.IsPathIn at the outset because we
 	// want to draw as much as possible before failing.
 	for i, n := range path {
-		if !l.Has(n) || (i != 0 && !l.HasEdge(path[i-1], n)) {
+		if !l.Has(n) || (i != 0 && !l.HasEdgeBetween(path[i-1], n)) {
 			id := n.ID()
 			if id >= 0 && id < len(l.Grid.open) {
 				r, c := l.RowCol(n.ID())

--- a/path/internal/limited_test.go
+++ b/path/internal/limited_test.go
@@ -1172,16 +1172,16 @@ func TestLimitedVisionGrid(t *testing.T) {
 			for _, v := range l.Nodes() {
 				vx, vy := l.XY(v)
 				vNear := math.Hypot(x-vx, y-vy) <= test.radius
-				if u.ID() == v.ID() && l.HasEdge(u, v) {
+				if u.ID() == v.ID() && l.HasEdgeBetween(u, v) {
 					t.Errorf("unexpected self edge: %v -- %v", u, v)
 				}
-				if !uNear && !vNear && !l.HasEdge(u, v) && couldConnectIn(l, u, v) {
+				if !uNear && !vNear && !l.HasEdgeBetween(u, v) && couldConnectIn(l, u, v) {
 					t.Errorf("unexpected pessimism: no hope in distant edge between %v and %v for test %d",
 						u, v, i)
 				}
-				if (uNear && vNear) && l.HasEdge(u, v) != l.Grid.HasEdge(u, v) {
+				if (uNear && vNear) && l.HasEdgeBetween(u, v) != l.Grid.HasEdgeBetween(u, v) {
 					t.Errorf("unrealistic optimism: disagreement about edge between %v and %v for test %d: got:%t want:%t",
-						u, v, i, l.HasEdge(u, v), l.Grid.HasEdge(u, v))
+						u, v, i, l.HasEdgeBetween(u, v), l.Grid.HasEdgeBetween(u, v))
 				}
 			}
 		}

--- a/path/johnson_apsp.go
+++ b/path/johnson_apsp.go
@@ -129,7 +129,7 @@ func (g johnsonWeightAdjuster) Weight(x, y graph.Node) (w float64, ok bool) {
 	return w + g.adjustBy.WeightTo(x) - g.adjustBy.WeightTo(y), ok
 }
 
-func (johnsonWeightAdjuster) HasEdge(_, _ graph.Node) bool {
+func (johnsonWeightAdjuster) HasEdgeBetween(_, _ graph.Node) bool {
 	panic("search: unintended use of johnsonWeightAdjuster")
 }
 

--- a/path/spanning_tree.go
+++ b/path/spanning_tree.go
@@ -51,7 +51,7 @@ func Prim(dst graph.UndirectedBuilder, g UndirectedWeighter) float64 {
 	var w float64
 	for q.Len() > 0 {
 		e := heap.Pop(q).(simple.Edge)
-		if e.To() != nil && g.HasEdge(e.From(), e.To()) {
+		if e.To() != nil && g.HasEdgeBetween(e.From(), e.To()) {
 			dst.SetEdge(e)
 			w += e.Weight()
 		}

--- a/simple/dense_directed_matrix.go
+++ b/simple/dense_directed_matrix.go
@@ -102,14 +102,14 @@ func (g *DirectedDenseGraph) To(n graph.Node) []graph.Node {
 	return neighbors
 }
 
-func (g *DirectedDenseGraph) HasEdge(x, y graph.Node) bool {
+func (g *DirectedDenseGraph) HasEdgeBetween(x, y graph.Node) bool {
 	xid := x.ID()
 	yid := y.ID()
 	return xid != yid && (!isSame(g.mat.At(xid, yid), g.absent) || !isSame(g.mat.At(yid, xid), g.absent))
 }
 
 func (g *DirectedDenseGraph) Edge(u, v graph.Node) graph.Edge {
-	if g.HasEdge(u, v) {
+	if g.HasEdgeBetween(u, v) {
 		return Edge{F: u, T: v, W: g.mat.At(u.ID(), v.ID())}
 	}
 	return nil

--- a/simple/dense_undirected_matrix.go
+++ b/simple/dense_undirected_matrix.go
@@ -99,7 +99,7 @@ func (g *UndirectedDenseGraph) From(n graph.Node) []graph.Node {
 	return neighbors
 }
 
-func (g *UndirectedDenseGraph) HasEdge(u, v graph.Node) bool {
+func (g *UndirectedDenseGraph) HasEdgeBetween(u, v graph.Node) bool {
 	uid := u.ID()
 	vid := v.ID()
 	return uid != vid && !isSame(g.mat.At(uid, vid), g.absent)
@@ -110,7 +110,7 @@ func (g *UndirectedDenseGraph) Edge(u, v graph.Node) graph.Edge {
 }
 
 func (g *UndirectedDenseGraph) EdgeBetween(u, v graph.Node) graph.Edge {
-	if g.HasEdge(u, v) {
+	if g.HasEdgeBetween(u, v) {
 		return Edge{F: u, T: v, W: g.mat.At(u.ID(), v.ID())}
 	}
 	return nil

--- a/simple/directed.go
+++ b/simple/directed.go
@@ -159,7 +159,7 @@ func (g *DirectedGraph) From(n graph.Node) []graph.Node {
 	return successors
 }
 
-func (g *DirectedGraph) HasEdge(x, y graph.Node) bool {
+func (g *DirectedGraph) HasEdgeBetween(x, y graph.Node) bool {
 	xid := x.ID()
 	yid := y.ID()
 	if _, ok := g.nodeMap[xid]; !ok {

--- a/simple/undirected.go
+++ b/simple/undirected.go
@@ -148,7 +148,7 @@ func (g *UndirectedGraph) From(n graph.Node) []graph.Node {
 	return neighbors
 }
 
-func (g *UndirectedGraph) HasEdge(n, neigh graph.Node) bool {
+func (g *UndirectedGraph) HasEdgeBetween(n, neigh graph.Node) bool {
 	_, ok := g.neighbors[n.ID()][neigh.ID()]
 	return ok
 }

--- a/topo/johnson_cycles.go
+++ b/topo/johnson_cycles.go
@@ -267,7 +267,7 @@ func (g johnsonGraph) From(n graph.Node) []graph.Node {
 func (johnsonGraph) Has(graph.Node) bool {
 	panic("search: unintended use of johnsonGraph")
 }
-func (johnsonGraph) HasEdge(_, _ graph.Node) bool {
+func (johnsonGraph) HasEdgeBetween(_, _ graph.Node) bool {
 	panic("search: unintended use of johnsonGraph")
 }
 func (johnsonGraph) Edge(_, _ graph.Node) graph.Edge {

--- a/topo/topo.go
+++ b/topo/topo.go
@@ -25,7 +25,7 @@ func IsPathIn(g graph.Graph, path []graph.Node) bool {
 		case graph.Directed:
 			canReach = g.HasEdgeFromTo
 		default:
-			canReach = g.HasEdge
+			canReach = g.HasEdgeBetween
 		}
 
 		for i, u := range path[:len(path)-1] {


### PR DESCRIPTION
The new name is clearer with respect to the semantics of the method and removing HasEdge allows implementations to add a HasEdge(graph.Edge) method.

Suggested off-line by Vladimir.

@vladimir-ch Please take a look.