### PR TITLE
topo: use use golang.org/x/.../intsets for TarjanSCC

### DIFF
--- a/path/bench_test.go
+++ b/path/bench_test.go
@@ -1,0 +1,142 @@
+// Copyright ©2015 The gonum Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package path
+
+import (
+	"math"
+	"testing"
+
+	"github.com/gonum/graph"
+	"github.com/gonum/graph/graphs/gen"
+	"github.com/gonum/graph/simple"
+)
+
+var (
+	gnpUndirected_10_tenth   = gnpUndirected(10, 0.1)
+	gnpUndirected_100_tenth  = gnpUndirected(100, 0.1)
+	gnpUndirected_1000_tenth = gnpUndirected(1000, 0.1)
+	gnpUndirected_10_half    = gnpUndirected(10, 0.5)
+	gnpUndirected_100_half   = gnpUndirected(100, 0.5)
+	gnpUndirected_1000_half  = gnpUndirected(1000, 0.5)
+)
+
+func gnpUndirected(n int, p float64) graph.Undirected {
+	g := simple.NewUndirectedGraph(0, math.Inf(1))
+	gen.Gnp(g, n, p, nil)
+	return g
+}
+
+func benchmarkAStarNilHeuristic(b *testing.B, g graph.Undirected) {
+	var expanded int
+	for i := 0; i < b.N; i++ {
+		_, expanded = AStar(simple.Node(0), simple.Node(1), g, nil)
+	}
+	if expanded == 0 {
+		b.Fatal("unexpected number of expanded nodes")
+	}
+}
+
+func BenchmarkAStarGnp_10_tenth(b *testing.B) {
+	benchmarkAStarNilHeuristic(b, gnpUndirected_10_tenth)
+}
+func BenchmarkAStarGnp_100_tenth(b *testing.B) {
+	benchmarkAStarNilHeuristic(b, gnpUndirected_100_tenth)
+}
+func BenchmarkAStarGnp_1000_tenth(b *testing.B) {
+	benchmarkAStarNilHeuristic(b, gnpUndirected_1000_tenth)
+}
+func BenchmarkAStarGnp_10_half(b *testing.B) {
+	benchmarkAStarNilHeuristic(b, gnpUndirected_10_half)
+}
+func BenchmarkAStarGnp_100_half(b *testing.B) {
+	benchmarkAStarNilHeuristic(b, gnpUndirected_100_half)
+}
+func BenchmarkAStarGnp_1000_half(b *testing.B) {
+	benchmarkAStarNilHeuristic(b, gnpUndirected_1000_half)
+}
+
+var (
+	nswUndirected_10_2_2_2   = navigableSmallWorldUndirected(10, 2, 2, 2)
+	nswUndirected_10_2_5_2   = navigableSmallWorldUndirected(10, 2, 5, 2)
+	nswUndirected_100_5_10_2 = navigableSmallWorldUndirected(100, 5, 10, 2)
+	nswUndirected_100_5_20_2 = navigableSmallWorldUndirected(100, 5, 20, 2)
+)
+
+func navigableSmallWorldUndirected(n, p, q int, r float64) graph.Undirected {
+	g := simple.NewUndirectedGraph(0, math.Inf(1))
+	gen.NavigableSmallWorld(g, []int{n, n}, p, q, r, nil)
+	return g
+}
+
+func coordinatesForID(n graph.Node, c, r int) [2]int {
+	id := n.ID()
+	if id >= c*r {
+		panic("out of range")
+	}
+	return [2]int{id / r, id % r}
+}
+
+// manhattanBetween returns the Manhattan distance between a and b.
+func manhattanBetween(a, b [2]int) float64 {
+	var d int
+	for i, v := range a {
+		d += abs(v - b[i])
+	}
+	return float64(d)
+}
+
+func abs(a int) int {
+	if a < 0 {
+		return -a
+	}
+	return a
+}
+
+func benchmarkAStarHeuristic(b *testing.B, g graph.Undirected, h Heuristic) {
+	var expanded int
+	for i := 0; i < b.N; i++ {
+		_, expanded = AStar(simple.Node(0), simple.Node(1), g, h)
+	}
+	if expanded == 0 {
+		b.Fatal("unexpected number of expanded nodes")
+	}
+}
+
+func BenchmarkAStarUndirectedmallWorld_10_2_2_2(b *testing.B) {
+	benchmarkAStarHeuristic(b, nswUndirected_10_2_2_2, nil)
+}
+func BenchmarkAStarUndirectedmallWorld_10_2_2_2_Heur(b *testing.B) {
+	h := func(x, y graph.Node) float64 {
+		return manhattanBetween(coordinatesForID(x, 10, 10), coordinatesForID(y, 10, 10))
+	}
+	benchmarkAStarHeuristic(b, nswUndirected_10_2_2_2, h)
+}
+func BenchmarkAStarUndirectedmallWorld_10_2_5_2(b *testing.B) {
+	benchmarkAStarHeuristic(b, nswUndirected_10_2_2_2, nil)
+}
+func BenchmarkAStarUndirectedmallWorld_10_2_5_2_Heur(b *testing.B) {
+	h := func(x, y graph.Node) float64 {
+		return manhattanBetween(coordinatesForID(x, 10, 10), coordinatesForID(y, 10, 10))
+	}
+	benchmarkAStarHeuristic(b, nswUndirected_10_2_2_2, h)
+}
+func BenchmarkAStarUndirectedmallWorld_100_5_10_2(b *testing.B) {
+	benchmarkAStarHeuristic(b, nswUndirected_100_5_10_2, nil)
+}
+func BenchmarkAStarUndirectedmallWorld_100_5_10_2_Heur(b *testing.B) {
+	h := func(x, y graph.Node) float64 {
+		return manhattanBetween(coordinatesForID(x, 100, 100), coordinatesForID(y, 100, 100))
+	}
+	benchmarkAStarHeuristic(b, nswUndirected_100_5_10_2, h)
+}
+func BenchmarkAStarUndirectedmallWorld_100_5_20_2(b *testing.B) {
+	benchmarkAStarHeuristic(b, nswUndirected_100_5_20_2, nil)
+}
+func BenchmarkAStarUndirectedmallWorld_100_5_20_2_Heur(b *testing.B) {
+	h := func(x, y graph.Node) float64 {
+		return manhattanBetween(coordinatesForID(x, 100, 100), coordinatesForID(y, 100, 100))
+	}
+	benchmarkAStarHeuristic(b, nswUndirected_100_5_20_2, h)
+}

--- a/topo/bench_test.go
+++ b/topo/bench_test.go
@@ -1,0 +1,58 @@
+// Copyright ©2015 The gonum Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package topo
+
+import (
+	"math"
+	"testing"
+
+	"github.com/gonum/graph"
+	"github.com/gonum/graph/graphs/gen"
+	"github.com/gonum/graph/simple"
+)
+
+var (
+	gnpDirected_10_tenth   = gnpDirected(10, 0.1)
+	gnpDirected_100_tenth  = gnpDirected(100, 0.1)
+	gnpDirected_1000_tenth = gnpDirected(1000, 0.1)
+	gnpDirected_10_half    = gnpDirected(10, 0.5)
+	gnpDirected_100_half   = gnpDirected(100, 0.5)
+	gnpDirected_1000_half  = gnpDirected(1000, 0.5)
+)
+
+func gnpDirected(n int, p float64) graph.Directed {
+	g := simple.NewDirectedGraph(0, math.Inf(1))
+	gen.Gnp(g, n, p, nil)
+	return g
+}
+
+func benchmarkTarjanSCC(b *testing.B, g graph.Directed) {
+	var sccs [][]graph.Node
+	for i := 0; i < b.N; i++ {
+		sccs = TarjanSCC(g)
+	}
+	if len(sccs) == 0 {
+		b.Fatal("unexpected number zero-sized SCC set")
+	}
+}
+
+func BenchmarkTarjanSCCGnp_10_tenth(b *testing.B) {
+	benchmarkTarjanSCC(b, gnpDirected_10_tenth)
+}
+func BenchmarkTarjanSCCGnp_100_tenth(b *testing.B) {
+	benchmarkTarjanSCC(b, gnpDirected_100_tenth)
+}
+func BenchmarkTarjanSCCGnp_1000_tenth(b *testing.B) {
+	benchmarkTarjanSCC(b, gnpDirected_1000_tenth)
+}
+func BenchmarkTarjanSCCGnp_10_half(b *testing.B) {
+	benchmarkTarjanSCC(b, gnpDirected_10_half)
+}
+func BenchmarkTarjanSCCGnp_100_half(b *testing.B) {
+	benchmarkTarjanSCC(b, gnpDirected_100_half)
+}
+func BenchmarkTarjanSCCGnp_1000_half(b *testing.B) {
+	benchmarkTarjanSCC(b, gnpDirected_1000_half)
+}

--- a/topo/tarjan.go
+++ b/topo/tarjan.go
@@ -8,8 +8,9 @@ import (
 	"fmt"
 	"sort"
 
+	"golang.org/x/tools/container/intsets"
+
 	"github.com/gonum/graph"
-	"github.com/gonum/graph/internal"
 )
 
 // Unorderable is an error containing sets of unorderable graph.Nodes.
@@ -79,7 +80,7 @@ func TarjanSCC(g graph.Directed) [][]graph.Node {
 
 		indexTable: make(map[int]int, len(nodes)),
 		lowLink:    make(map[int]int, len(nodes)),
-		onStack:    make(internal.IntSet, len(nodes)),
+		onStack:    &intsets.Sparse{},
 	}
 	for _, v := range nodes {
 		if t.indexTable[v.ID()] == 0 {
@@ -100,7 +101,7 @@ type tarjan struct {
 	index      int
 	indexTable map[int]int
 	lowLink    map[int]int
-	onStack    internal.IntSet
+	onStack    *intsets.Sparse
 
 	stack []graph.Node
 
@@ -117,7 +118,7 @@ func (t *tarjan) strongconnect(v graph.Node) {
 	t.indexTable[vID] = t.index
 	t.lowLink[vID] = t.index
 	t.stack = append(t.stack, v)
-	t.onStack.Add(vID)
+	t.onStack.Insert(vID)
 
 	// Consider successors of v.
 	for _, w := range t.succ(v) {

--- a/traverse/traverse_test.go
+++ b/traverse/traverse_test.go
@@ -371,7 +371,7 @@ func gnpUndirected(n int, p float64) graph.Undirected {
 	return g
 }
 
-func benchMarkWalkAllBreadthFirst(b *testing.B, g graph.Undirected) {
+func benchmarkWalkAllBreadthFirst(b *testing.B, g graph.Undirected) {
 	n := len(g.Nodes())
 	b.ResetTimer()
 	var bft BreadthFirst
@@ -379,30 +379,30 @@ func benchMarkWalkAllBreadthFirst(b *testing.B, g graph.Undirected) {
 		bft.WalkAll(g, nil, nil, nil)
 	}
 	if bft.visited.Len() != n {
-		b.Errorf("unexpected number of nodes visited: want: %d got %d", n, bft.visited.Len())
+		b.Fatalf("unexpected number of nodes visited: want: %d got %d", n, bft.visited.Len())
 	}
 }
 
 func BenchmarkWalkAllBreadthFirstGnp_10_tenth(b *testing.B) {
-	benchMarkWalkAllBreadthFirst(b, gnpUndirected_10_tenth)
+	benchmarkWalkAllBreadthFirst(b, gnpUndirected_10_tenth)
 }
 func BenchmarkWalkAllBreadthFirstGnp_100_tenth(b *testing.B) {
-	benchMarkWalkAllBreadthFirst(b, gnpUndirected_100_tenth)
+	benchmarkWalkAllBreadthFirst(b, gnpUndirected_100_tenth)
 }
 func BenchmarkWalkAllBreadthFirstGnp_1000_tenth(b *testing.B) {
-	benchMarkWalkAllBreadthFirst(b, gnpUndirected_1000_tenth)
+	benchmarkWalkAllBreadthFirst(b, gnpUndirected_1000_tenth)
 }
 func BenchmarkWalkAllBreadthFirstGnp_10_half(b *testing.B) {
-	benchMarkWalkAllBreadthFirst(b, gnpUndirected_10_half)
+	benchmarkWalkAllBreadthFirst(b, gnpUndirected_10_half)
 }
 func BenchmarkWalkAllBreadthFirstGnp_100_half(b *testing.B) {
-	benchMarkWalkAllBreadthFirst(b, gnpUndirected_100_half)
+	benchmarkWalkAllBreadthFirst(b, gnpUndirected_100_half)
 }
 func BenchmarkWalkAllBreadthFirstGnp_1000_half(b *testing.B) {
-	benchMarkWalkAllBreadthFirst(b, gnpUndirected_1000_half)
+	benchmarkWalkAllBreadthFirst(b, gnpUndirected_1000_half)
 }
 
-func benchMarkWalkAllDepthFirst(b *testing.B, g graph.Undirected) {
+func benchmarkWalkAllDepthFirst(b *testing.B, g graph.Undirected) {
 	n := len(g.Nodes())
 	b.ResetTimer()
 	var dft DepthFirst
@@ -410,25 +410,25 @@ func benchMarkWalkAllDepthFirst(b *testing.B, g graph.Undirected) {
 		dft.WalkAll(g, nil, nil, nil)
 	}
 	if dft.visited.Len() != n {
-		b.Errorf("unexpected number of nodes visited: want: %d got %d", n, dft.visited.Len())
+		b.Fatalf("unexpected number of nodes visited: want: %d got %d", n, dft.visited.Len())
 	}
 }
 
 func BenchmarkWalkAllDepthFirstGnp_10_tenth(b *testing.B) {
-	benchMarkWalkAllDepthFirst(b, gnpUndirected_10_tenth)
+	benchmarkWalkAllDepthFirst(b, gnpUndirected_10_tenth)
 }
 func BenchmarkWalkAllDepthFirstGnp_100_tenth(b *testing.B) {
-	benchMarkWalkAllDepthFirst(b, gnpUndirected_100_tenth)
+	benchmarkWalkAllDepthFirst(b, gnpUndirected_100_tenth)
 }
 func BenchmarkWalkAllDepthFirstGnp_1000_tenth(b *testing.B) {
-	benchMarkWalkAllDepthFirst(b, gnpUndirected_1000_tenth)
+	benchmarkWalkAllDepthFirst(b, gnpUndirected_1000_tenth)
 }
 func BenchmarkWalkAllDepthFirstGnp_10_half(b *testing.B) {
-	benchMarkWalkAllDepthFirst(b, gnpUndirected_10_half)
+	benchmarkWalkAllDepthFirst(b, gnpUndirected_10_half)
 }
 func BenchmarkWalkAllDepthFirstGnp_100_half(b *testing.B) {
-	benchMarkWalkAllDepthFirst(b, gnpUndirected_100_half)
+	benchmarkWalkAllDepthFirst(b, gnpUndirected_100_half)
 }
 func BenchmarkWalkAllDepthFirstGnp_1000_half(b *testing.B) {
-	benchMarkWalkAllDepthFirst(b, gnpUndirected_1000_half)
+	benchmarkWalkAllDepthFirst(b, gnpUndirected_1000_half)
 }


### PR DESCRIPTION
I have looked at similar changes for CyclesIn, but the benefits are mixed, more complicated and incomplete, and clearly not worth the change:

```
name                  old mean              new mean              delta
CyclesInGnp_10_tenth  46.1µs × (1.00,1.00)  44.9µs × (0.98,1.01)   -2.46% (p=0.000 n=9+9)
CyclesInGnp_20_tenth  1.63ms × (1.00,1.00)  1.71ms × (1.00,1.01)  +4.92% (p=0.000 n=10+8)
CyclesInGnp_10_half   8.03ms × (1.00,1.00)  8.14ms × (0.96,1.01)    ~    (p=0.156 n=9+10)
```

Also fix spelling.

@vladimir-ch Please take a look.