### PR TITLE
community: add directed louvain implementation

### DIFF
--- a/community/louvain_common.go
+++ b/community/louvain_common.go
@@ -1,0 +1,68 @@
+// Copyright ©2015 The gonum Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// Package community provides graph community detection functions.
+package community
+
+import "github.com/gonum/graph"
+
+// community is a reduced graph node describing its membership.
+type community struct {
+	id int
+
+	nodes  []graph.Node
+	weight float64
+}
+
+func (n community) ID() int { return n.id }
+
+// edge is a reduced graph edge.
+type edge struct {
+	from, to community
+	weight   float64
+}
+
+func (e edge) From() graph.Node { return e.from }
+func (e edge) To() graph.Node   { return e.to }
+func (e edge) Weight() float64  { return e.weight }
+
+// commIdx is an index of a node in a community held by a localMover.
+type commIdx struct {
+	community int
+	node      int
+}
+
+// node is defined to avoid an import of .../graph/simple.
+type node int
+
+func (n node) ID() int { return int(n) }
+
+const negativeWeight = "community: negative edge weight"
+
+// weightFuncFor returns a constructed weight function for g.
+func weightFuncFor(g graph.Graph) func(x, y graph.Node) float64 {
+	if wg, ok := g.(graph.Weighter); ok {
+		return func(x, y graph.Node) float64 {
+			w, ok := wg.Weight(x, y)
+			if !ok {
+				return 0
+			}
+			if w < 0 {
+				panic(negativeWeight)
+			}
+			return w
+		}
+	}
+	return func(x, y graph.Node) float64 {
+		e := g.Edge(x, y)
+		if e == nil {
+			return 0
+		}
+		w := e.Weight()
+		if w < 0 {
+			panic(negativeWeight)
+		}
+		return w
+	}
+}

--- a/community/louvain_common.go
+++ b/community/louvain_common.go
@@ -5,7 +5,35 @@
 // Package community provides graph community detection functions.
 package community
 
-import "github.com/gonum/graph"
+import (
+	"fmt"
+
+	"github.com/gonum/graph"
+)
+
+// Q returns the modularity Q score of the graph g subdivided into the
+// given communities at the given resolution. If communities is nil, the
+// unclustered modularity score is returned. The resolution parameter
+// is γ as defined in Reichardt and Bornholdt doi:10.1103/PhysRevE.74.016110.
+// Q will panic if g has any edge with negative edge weight.
+//
+// If g is undirected, Q is calculated according to
+//  Q = 1/2m \sum_{ij} [ A_{ij} - (\gamma k_i k_j)/2m ] \delta(c_i,c_j),
+// If g is directed, it is calculated according to
+//  Q = 1/m \sum_{ij} [ A_{ij} - (\gamma k_i^in k_j^out)/m ] \delta(c_i,c_j).
+//
+// graph.Undirect may be used as a shim to allow calculation of Q for
+// directed graphs with the undirected modularity function.
+func Q(g graph.Graph, communities [][]graph.Node, resolution float64) float64 {
+	switch g := g.(type) {
+	case graph.Undirected:
+		return qUndirected(g, communities, resolution)
+	case graph.Directed:
+		return qDirected(g, communities, resolution)
+	default:
+		panic(fmt.Sprintf("community: invalid graph type: %T", g))
+	}
+}
 
 // community is a reduced graph node describing its membership.
 type community struct {

--- a/community/louvain_directed_test.go
+++ b/community/louvain_directed_test.go
@@ -17,131 +17,75 @@ import (
 	"github.com/gonum/graph/simple"
 )
 
-var communityUndirectedQTests = []struct {
+var communityDirectedQTests = []struct {
 	name       string
 	g          []set
 	structures []structure
 
 	wantLevels []level
 }{
-	// The java reference implementation is available from http://www.ludowaltman.nl/slm/.
 	{
-		name: "unconnected",
-		g:    unconnected,
+		name: "simple_directed",
+		g: []set{
+			0: linksTo(1),
+			1: linksTo(0, 4),
+			2: linksTo(1),
+			3: linksTo(0, 4),
+			4: linksTo(2),
+		},
+		// community structure and modularity calculated by C++ implementation: louvain igraph.
+		// Note that louvain igraph returns Q as an unscaled value.
 		structures: []structure{
 			{
 				resolution: 1,
 				memberships: []set{
-					0: linksTo(0),
-					1: linksTo(1),
-					2: linksTo(2),
-					3: linksTo(3),
-					4: linksTo(4),
-					5: linksTo(5),
+					0: linksTo(0, 1),
+					1: linksTo(2, 3, 4),
 				},
-				want: math.NaN(),
+				want: 0.5714285714285716 / 7,
+				tol:  1e-10,
 			},
 		},
 		wantLevels: []level{
 			{
-				q: math.Inf(-1), // Here math.Inf(-1) is used as a place holder for NaN to allow use of reflect.DeepEqual.
+				communities: [][]graph.Node{
+					{simple.Node(0), simple.Node(1)},
+					{simple.Node(2), simple.Node(3), simple.Node(4)},
+				},
+				q: 0.5714285714285716 / 7,
+			},
+			{
 				communities: [][]graph.Node{
 					{simple.Node(0)},
 					{simple.Node(1)},
 					{simple.Node(2)},
 					{simple.Node(3)},
 					{simple.Node(4)},
-					{simple.Node(5)},
 				},
-			},
-		},
-	},
-	{
-		name: "small_dumbell",
-		g:    smallDumbell,
-		structures: []structure{
-			{
-				resolution: 1,
-				// community structure and modularity calculated by java reference implementation.
-				memberships: []set{
-					0: linksTo(0, 1, 2),
-					1: linksTo(3, 4, 5),
-				},
-				want: 0.357, tol: 1e-3,
-			},
-			{
-				resolution: 1,
-				memberships: []set{
-					0: linksTo(0, 1, 2, 3, 4, 5),
-				},
-				// theoretical expectation.
-				want: 0, tol: 1e-14,
-			},
-		},
-		wantLevels: []level{
-			{
-				q: 0.35714285714285715,
-				communities: [][]graph.Node{
-					{simple.Node(0), simple.Node(1), simple.Node(2)},
-					{simple.Node(3), simple.Node(4), simple.Node(5)},
-				},
-			},
-			{
-				q: -0.17346938775510204,
-				communities: [][]graph.Node{
-					{simple.Node(0)},
-					{simple.Node(1)},
-					{simple.Node(2)},
-					{simple.Node(3)},
-					{simple.Node(4)},
-					{simple.Node(5)},
-				},
+				q: -1.2857142857142856 / 7,
 			},
 		},
 	},
 	{
 		name: "zachary",
 		g:    zachary,
+		// community structure and modularity calculated by C++ implementation: louvain igraph.
+		// Note that louvain igraph returns Q as an unscaled value.
 		structures: []structure{
 			{
 				resolution: 1,
-				// community structure and modularity from doi: 10.1140/epjb/e2013-40829-0
 				memberships: []set{
 					0: linksTo(0, 1, 2, 3, 7, 11, 12, 13, 17, 19, 21),
 					1: linksTo(4, 5, 6, 10, 16),
 					2: linksTo(8, 9, 14, 15, 18, 20, 22, 26, 29, 30, 32, 33),
 					3: linksTo(23, 24, 25, 27, 28, 31),
 				},
-				// Noted to be the optimal modularisation in the paper above.
-				want: 0.4198, tol: 1e-4,
-			},
-			{
-				resolution: 0.5,
-				// community structure and modularity calculated by java reference implementation.
-				memberships: []set{
-					0: linksTo(0, 1, 2, 3, 4, 5, 6, 7, 9, 10, 11, 12, 13, 16, 17, 19, 21),
-					1: linksTo(8, 14, 15, 18, 20, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33),
-				},
-				want: 0.6218, tol: 1e-3,
-			},
-			{
-				resolution: 2,
-				// community structure and modularity calculated by java reference implementation.
-				memberships: []set{
-					0: linksTo(14, 18, 20, 22, 32, 33, 15),
-					1: linksTo(0, 1, 11, 17, 19, 21),
-					2: linksTo(2, 3, 7, 9, 12, 13),
-					3: linksTo(4, 5, 6, 10, 16),
-					4: linksTo(24, 25, 28, 31),
-					5: linksTo(23, 26, 27, 29),
-					6: linksTo(8, 30),
-				},
-				want: 0.1645, tol: 1e-3,
+				want: 34.3417721519 / 79 /* 5->6 and 6->5 because of co-equal rank */, tol: 1e-4,
 			},
 		},
 		wantLevels: []level{
 			{
-				q: 0.4197896120973044,
+				q: 0.43470597660631316,
 				communities: [][]graph.Node{
 					{simple.Node(0), simple.Node(1), simple.Node(2), simple.Node(3), simple.Node(7), simple.Node(11), simple.Node(12), simple.Node(13), simple.Node(17), simple.Node(19), simple.Node(21)},
 					{simple.Node(4), simple.Node(5), simple.Node(6), simple.Node(10), simple.Node(16)},
@@ -150,17 +94,19 @@ var communityUndirectedQTests = []struct {
 				},
 			},
 			{
-				q: 0.39907955292570674,
+				q: 0.3911232174331037,
 				communities: [][]graph.Node{
 					{simple.Node(0), simple.Node(1), simple.Node(2), simple.Node(3), simple.Node(7), simple.Node(11), simple.Node(12), simple.Node(13), simple.Node(17), simple.Node(19), simple.Node(21)},
 					{simple.Node(4), simple.Node(10)},
 					{simple.Node(5), simple.Node(6), simple.Node(16)},
-					{simple.Node(8), simple.Node(9), simple.Node(14), simple.Node(15), simple.Node(18), simple.Node(20), simple.Node(22), simple.Node(26), simple.Node(29), simple.Node(30), simple.Node(32), simple.Node(33)},
+					{simple.Node(8), simple.Node(30)},
+					{simple.Node(9), simple.Node(14), simple.Node(15), simple.Node(18), simple.Node(20), simple.Node(22), simple.Node(32), simple.Node(33)},
 					{simple.Node(23), simple.Node(24), simple.Node(25), simple.Node(27), simple.Node(28), simple.Node(31)},
+					{simple.Node(26), simple.Node(29)},
 				},
 			},
 			{
-				q: -0.04980276134122286,
+				q: -0.014580996635154624,
 				communities: [][]graph.Node{
 					{simple.Node(0)},
 					{simple.Node(1)},
@@ -203,36 +149,37 @@ var communityUndirectedQTests = []struct {
 	{
 		name: "blondel",
 		g:    blondel,
+		// community structure and modularity calculated by C++ implementation: louvain igraph.
+		// Note that louvain igraph returns Q as an unscaled value.
 		structures: []structure{
 			{
 				resolution: 1,
-				// community structure and modularity calculated by java reference implementation.
 				memberships: []set{
 					0: linksTo(0, 1, 2, 3, 4, 5, 6, 7),
 					1: linksTo(8, 9, 10, 11, 12, 13, 14, 15),
 				},
-				want: 0.3922, tol: 1e-4,
+				want: 11.1428571429 / 28, tol: 1e-4,
 			},
 		},
 		wantLevels: []level{
 			{
-				q: 0.39221938775510207,
+				q: 0.3979591836734694,
 				communities: [][]graph.Node{
 					{simple.Node(0), simple.Node(1), simple.Node(2), simple.Node(3), simple.Node(4), simple.Node(5), simple.Node(6), simple.Node(7)},
 					{simple.Node(8), simple.Node(9), simple.Node(10), simple.Node(11), simple.Node(12), simple.Node(13), simple.Node(14), simple.Node(15)},
 				},
 			},
 			{
-				q: 0.34630102040816324,
+				q: 0.32525510204081637,
 				communities: [][]graph.Node{
-					{simple.Node(0), simple.Node(1), simple.Node(2), simple.Node(4), simple.Node(5)},
-					{simple.Node(3), simple.Node(6), simple.Node(7)},
-					{simple.Node(8), simple.Node(9), simple.Node(10), simple.Node(12), simple.Node(14), simple.Node(15)},
-					{simple.Node(11), simple.Node(13)},
+					{simple.Node(0), simple.Node(3), simple.Node(5), simple.Node(7)},
+					{simple.Node(1), simple.Node(2), simple.Node(4), simple.Node(6)},
+					{simple.Node(8), simple.Node(10), simple.Node(11), simple.Node(13), simple.Node(15)},
+					{simple.Node(9), simple.Node(12), simple.Node(14)},
 				},
 			},
 			{
-				q: -0.07142857142857144,
+				q: -0.022959183673469385,
 				communities: [][]graph.Node{
 					{simple.Node(0)},
 					{simple.Node(1)},
@@ -256,9 +203,9 @@ var communityUndirectedQTests = []struct {
 	},
 }
 
-func TestCommunityQUndirected(t *testing.T) {
-	for _, test := range communityUndirectedQTests {
-		g := simple.NewUndirectedGraph(0, 0)
+func TestCommunityQDirected(t *testing.T) {
+	for _, test := range communityDirectedQTests {
+		g := simple.NewDirectedGraph(0, 0)
 		for u, e := range test.g {
 			// Add nodes that are not defined by an edge.
 			if !g.Has(simple.Node(u)) {
@@ -287,10 +234,10 @@ func TestCommunityQUndirected(t *testing.T) {
 	}
 }
 
-func TestCommunityDeltaQUndirected(t *testing.T) {
+func TestCommunityDeltaQDirected(t *testing.T) {
 tests:
-	for _, test := range communityUndirectedQTests {
-		g := simple.NewUndirectedGraph(0, 0)
+	for _, test := range communityDirectedQTests {
+		g := simple.NewDirectedGraph(0, 0)
 		for u, e := range test.g {
 			// Add nodes that are not defined by an edge.
 			if !g.Has(simple.Node(u)) {
@@ -315,7 +262,7 @@ tests:
 
 			before := Q(g, communities, structure.resolution)
 
-			l := newUndirectedLocalMover(reduceUndirected(g, nil), communities, structure.resolution)
+			l := newDirectedLocalMover(reduceDirected(g, nil), communities, structure.resolution)
 			if l == nil {
 				if !math.IsNaN(before) {
 					t.Errorf("unexpected nil localMover with non-NaN Q graph: Q=%.4v", before)
@@ -390,10 +337,10 @@ tests:
 	}
 }
 
-func TestReduceQConsistencyUndirected(t *testing.T) {
+func TestReduceQConsistencyDirected(t *testing.T) {
 tests:
-	for _, test := range communityUndirectedQTests {
-		g := simple.NewUndirectedGraph(0, 0)
+	for _, test := range communityDirectedQTests {
+		g := simple.NewDirectedGraph(0, 0)
 		for u, e := range test.g {
 			// Add nodes that are not defined by an edge.
 			if !g.Has(simple.Node(u)) {
@@ -420,7 +367,7 @@ tests:
 			gQ := Q(g, communities, structure.resolution)
 			gQnull := Q(g, nil, 1)
 
-			cg0 := reduceUndirected(g, nil)
+			cg0 := reduceDirected(g, nil)
 			cg0Qnull := Q(cg0, cg0.Structure(), 1)
 			if !floats.EqualWithinAbsOrRel(gQnull, cg0Qnull, structure.tol, structure.tol) {
 				t.Errorf("disgagreement between null Q from method: %v and function: %v", cg0Qnull, gQnull)
@@ -430,7 +377,7 @@ tests:
 				t.Errorf("unexpected Q result after initial conversion: got: %v want :%v", gQ, cg0Q)
 			}
 
-			cg1 := reduceUndirected(cg0, communities)
+			cg1 := reduceDirected(cg0, communities)
 			cg1Q := Q(cg1, cg1.Structure(), structure.resolution)
 			if !floats.EqualWithinAbsOrRel(gQ, cg1Q, structure.tol, structure.tol) {
 				t.Errorf("unexpected Q result after initial condensation: got: %v want :%v", gQ, cg1Q)
@@ -439,7 +386,7 @@ tests:
 	}
 }
 
-var localUndirectedMoveTests = []struct {
+var localDirectedMoveTests = []struct {
 	name       string
 	g          []set
 	structures []moveStructures
@@ -486,9 +433,9 @@ var localUndirectedMoveTests = []struct {
 	},
 }
 
-func TestMoveLocalUndirected(t *testing.T) {
+func TestMoveLocalDirected(t *testing.T) {
 	for _, test := range localUndirectedMoveTests {
-		g := simple.NewUndirectedGraph(0, 0)
+		g := simple.NewDirectedGraph(0, 0)
 		for u, e := range test.g {
 			// Add nodes that are not defined by an edge.
 			if !g.Has(simple.Node(u)) {
@@ -508,9 +455,9 @@ func TestMoveLocalUndirected(t *testing.T) {
 				sort.Sort(ordered.ByID(communities[i]))
 			}
 
-			r := reduceUndirected(reduceUndirected(g, nil), communities)
+			r := reduceDirected(reduceDirected(g, nil), communities)
 
-			l := newUndirectedLocalMover(r, r.communities, structure.resolution)
+			l := newDirectedLocalMover(r, r.communities, structure.resolution)
 			for _, n := range structure.targetNodes {
 				dQ, dst, src := l.deltaQ(n)
 				if dQ > 0 {
@@ -527,11 +474,11 @@ func TestMoveLocalUndirected(t *testing.T) {
 	}
 }
 
-func TestLouvain(t *testing.T) {
+func TestLouvainDirected(t *testing.T) {
 	const louvainIterations = 20
 
-	for _, test := range communityUndirectedQTests {
-		g := simple.NewUndirectedGraph(0, 0)
+	for _, test := range communityDirectedQTests {
+		g := simple.NewDirectedGraph(0, 0)
 		for u, e := range test.g {
 			// Add nodes that are not defined by an edge.
 			if !g.Has(simple.Node(u)) {
@@ -555,14 +502,14 @@ func TestLouvain(t *testing.T) {
 		sort.Sort(ordered.BySliceIDs(want))
 
 		var (
-			got   *ReducedUndirected
+			got   *ReducedDirected
 			bestQ = math.Inf(-1)
 		)
 		// Louvain is randomised so we do this to
 		// ensure the level tests are consistent.
 		src := rand.New(rand.NewSource(1))
 		for i := 0; i < louvainIterations; i++ {
-			r := Louvain(g, 1, src)
+			r := LouvainDirected(g, 1, src)
 			if q := Q(r, nil, 1); q > bestQ || math.IsNaN(q) {
 				bestQ = q
 				got = r
@@ -605,7 +552,7 @@ func TestLouvain(t *testing.T) {
 				}
 				sort.Sort(ordered.BySliceIDs(communities))
 			} else {
-				communities = reduceUndirected(g, nil).Communities()
+				communities = reduceDirected(g, nil).Communities()
 			}
 			q := Q(p, nil, 1)
 			if math.IsNaN(q) {
@@ -620,8 +567,8 @@ func TestLouvain(t *testing.T) {
 	}
 }
 
-func TestNonContiguousUndirected(t *testing.T) {
-	g := simple.NewUndirectedGraph(0, 0)
+func TestNonContiguousDirected(t *testing.T) {
+	g := simple.NewDirectedGraph(0, 0)
 	for _, e := range []simple.Edge{
 		{F: simple.Node(0), T: simple.Node(1), W: 1},
 		{F: simple.Node(4), T: simple.Node(5), W: 1},
@@ -636,13 +583,13 @@ func TestNonContiguousUndirected(t *testing.T) {
 				t.Error("unexpected panic with non-contiguous ID range")
 			}
 		}()
-		Louvain(g, 1, nil)
+		LouvainDirected(g, 1, nil)
 	}()
 }
 
-func BenchmarkLouvain(b *testing.B) {
+func BenchmarkLouvainDirected(b *testing.B) {
 	src := rand.New(rand.NewSource(1))
 	for i := 0; i < b.N; i++ {
-		Louvain(dupGraph, 1, src)
+		LouvainDirected(dupGraphDirected, 1, src)
 	}
 }

--- a/community/louvain_test.go
+++ b/community/louvain_test.go
@@ -40,50 +40,71 @@ var (
 
 	// W. W. Zachary, An information flow model for conflict and fission in small groups,
 	// Journal of Anthropological Research 33, 452-473 (1977).
+	//
+	// The edge list here is constructed such that all link descriptions
+	// head from a node with lower Page Rank to a node with higher Page
+	// Rank. This has no impact on undirected tests, but allows a sensible
+	// view for directed tests.
 	zachary = []set{
-		0:  linksTo(1, 2, 3, 4, 5, 6, 7, 8, 10, 11, 12, 13, 17, 19, 21, 31),
-		1:  linksTo(2, 3, 7, 13, 17, 19, 21, 30),
-		2:  linksTo(3, 7, 8, 9, 13, 27, 28, 32),
-		3:  linksTo(7, 12, 13),
-		4:  linksTo(6, 10),
-		5:  linksTo(6, 10, 16),
-		6:  linksTo(16),
-		8:  linksTo(30, 32, 33),
-		9:  linksTo(33),
-		13: linksTo(33),
-		14: linksTo(32, 33),
-		15: linksTo(32, 33),
-		18: linksTo(32, 33),
-		19: linksTo(33),
-		20: linksTo(32, 33),
-		22: linksTo(32, 33),
-		23: linksTo(25, 27, 29, 32, 33),
-		24: linksTo(25, 27, 31),
-		25: linksTo(31),
-		26: linksTo(29, 33),
-		27: linksTo(33),
-		28: linksTo(31, 33),
-		29: linksTo(32, 33),
-		30: linksTo(32, 33),
-		31: linksTo(32, 33),
-		32: linksTo(33),
-		33: nil,
+		0:  nil,                     // rank=0.097
+		1:  linksTo(0, 2),           // rank=0.05288
+		2:  linksTo(0, 32),          // rank=0.05708
+		3:  linksTo(0, 1, 2),        // rank=0.03586
+		4:  linksTo(0, 6, 10),       // rank=0.02198
+		5:  linksTo(0, 6),           // rank=0.02911
+		6:  linksTo(0, 5),           // rank=0.02911
+		7:  linksTo(0, 1, 2, 3),     // rank=0.02449
+		8:  linksTo(0, 2, 32, 33),   // rank=0.02977
+		9:  linksTo(2, 33),          // rank=0.01431
+		10: linksTo(0, 5),           // rank=0.02198
+		11: linksTo(0),              // rank=0.009565
+		12: linksTo(0, 3),           // rank=0.01464
+		13: linksTo(0, 1, 2, 3, 33), // rank=0.02954
+		14: linksTo(32, 33),         // rank=0.01454
+		15: linksTo(32, 33),         // rank=0.01454
+		16: linksTo(5, 6),           // rank=0.01678
+		17: linksTo(0, 1),           // rank=0.01456
+		18: linksTo(32, 33),         // rank=0.01454
+		19: linksTo(0, 1, 33),       // rank=0.0196
+		20: linksTo(32, 33),         // rank=0.01454
+		21: linksTo(0, 1),           // rank=0.01456
+		22: linksTo(32, 33),         // rank=0.01454
+		23: linksTo(32, 33),         // rank=0.03152
+		24: linksTo(27, 31),         // rank=0.02108
+		25: linksTo(23, 24, 31),     // rank=0.02101
+		26: linksTo(29, 33),         // rank=0.01504
+		27: linksTo(2, 23, 33),      // rank=0.02564
+		28: linksTo(2, 31, 33),      // rank=0.01957
+		29: linksTo(23, 32, 33),     // rank=0.02629
+		30: linksTo(1, 8, 32, 33),   // rank=0.02459
+		31: linksTo(0, 32, 33),      // rank=0.03716
+		32: linksTo(33),             // rank=0.07169
+		33: nil,                     // rank=0.1009
 	}
 
 	// doi:10.1088/1742-5468/2008/10/P10008 figure 1
+	//
+	// The edge list here is constructed such that all link descriptions
+	// head from a node with lower Page Rank to a node with higher Page
+	// Rank. This has no impact on undirected tests, but allows a sensible
+	// view for directed tests.
 	blondel = []set{
-		0:  linksTo(2, 3, 4, 5),
-		1:  linksTo(2, 4, 7),
-		2:  linksTo(4, 5, 6),
-		3:  linksTo(7),
-		4:  linksTo(10),
-		5:  linksTo(7, 11),
-		6:  linksTo(7, 11),
-		8:  linksTo(9, 10, 11, 14, 15),
-		9:  linksTo(12, 14),
-		10: linksTo(11, 12, 13, 14),
-		11: linksTo(13),
-		15: nil,
+		0:  linksTo(2),           // rank=0.06858
+		1:  linksTo(2, 4, 7),     // rank=0.05264
+		2:  nil,                  // rank=0.08249
+		3:  linksTo(0, 7),        // rank=0.03884
+		4:  linksTo(0, 2, 10),    // rank=0.06754
+		5:  linksTo(0, 2, 7, 11), // rank=0.06738
+		6:  linksTo(2, 7, 11),    // rank=0.0528
+		7:  nil,                  // rank=0.07008
+		8:  linksTo(10),          // rank=0.09226
+		9:  linksTo(8),           // rank=0.05821
+		10: nil,                  // rank=0.1035
+		11: linksTo(8, 10),       // rank=0.08538
+		12: linksTo(9, 10),       // rank=0.04052
+		13: linksTo(10, 11),      // rank=0.03855
+		14: linksTo(8, 9, 10),    // rank=0.05621
+		15: linksTo(8),           // rank=0.02506
 	}
 )
 
@@ -112,11 +133,27 @@ func reverse(f []float64) {
 	}
 }
 
-var dupGraph = simple.NewUndirectedGraph(0, 0)
+var (
+	dupGraph         = simple.NewUndirectedGraph(0, 0)
+	dupGraphDirected = simple.NewDirectedGraph(0, 0)
+)
 
 func init() {
 	err := gen.Duplication(dupGraph, 1000, 0.8, 0.1, 0.5, rand.New(rand.NewSource(1)))
 	if err != nil {
 		panic(err)
+	}
+
+	// Construct a directed graph from dupGraph
+	// such that every edge dupGraph is replaced
+	// with an edge that flows from the low node
+	// ID to the high node ID.
+	for _, e := range dupGraph.Edges() {
+		if e.To().ID() < e.From().ID() {
+			se := e.(simple.Edge)
+			se.F, se.T = se.T, se.F
+			e = se
+		}
+		dupGraphDirected.SetEdge(e)
 	}
 }

--- a/community/louvain_test.go
+++ b/community/louvain_test.go
@@ -5,16 +5,10 @@
 package community
 
 import (
-	"math"
 	"math/rand"
-	"reflect"
-	"sort"
-	"testing"
 
-	"github.com/gonum/floats"
 	"github.com/gonum/graph"
 	"github.com/gonum/graph/graphs/gen"
-	"github.com/gonum/graph/internal/ordered"
 	"github.com/gonum/graph/simple"
 )
 
@@ -32,6 +26,67 @@ func linksTo(i ...int) set {
 	return s
 }
 
+var (
+	unconnected = []set{ /* Nodes 0-4 are implicit .*/ 5: nil}
+
+	smallDumbell = []set{
+		0: linksTo(1, 2),
+		1: linksTo(2),
+		2: linksTo(3),
+		3: linksTo(4, 5),
+		4: linksTo(5),
+		5: nil,
+	}
+
+	// W. W. Zachary, An information flow model for conflict and fission in small groups,
+	// Journal of Anthropological Research 33, 452-473 (1977).
+	zachary = []set{
+		0:  linksTo(1, 2, 3, 4, 5, 6, 7, 8, 10, 11, 12, 13, 17, 19, 21, 31),
+		1:  linksTo(2, 3, 7, 13, 17, 19, 21, 30),
+		2:  linksTo(3, 7, 8, 9, 13, 27, 28, 32),
+		3:  linksTo(7, 12, 13),
+		4:  linksTo(6, 10),
+		5:  linksTo(6, 10, 16),
+		6:  linksTo(16),
+		8:  linksTo(30, 32, 33),
+		9:  linksTo(33),
+		13: linksTo(33),
+		14: linksTo(32, 33),
+		15: linksTo(32, 33),
+		18: linksTo(32, 33),
+		19: linksTo(33),
+		20: linksTo(32, 33),
+		22: linksTo(32, 33),
+		23: linksTo(25, 27, 29, 32, 33),
+		24: linksTo(25, 27, 31),
+		25: linksTo(31),
+		26: linksTo(29, 33),
+		27: linksTo(33),
+		28: linksTo(31, 33),
+		29: linksTo(32, 33),
+		30: linksTo(32, 33),
+		31: linksTo(32, 33),
+		32: linksTo(33),
+		33: nil,
+	}
+
+	// doi:10.1088/1742-5468/2008/10/P10008 figure 1
+	blondel = []set{
+		0:  linksTo(2, 3, 4, 5),
+		1:  linksTo(2, 4, 7),
+		2:  linksTo(4, 5, 6),
+		3:  linksTo(7),
+		4:  linksTo(10),
+		5:  linksTo(7, 11),
+		6:  linksTo(7, 11),
+		8:  linksTo(9, 10, 11, 14, 15),
+		9:  linksTo(12, 14),
+		10: linksTo(11, 12, 13, 14),
+		11: linksTo(13),
+		15: nil,
+	}
+)
+
 type structure struct {
 	resolution  float64
 	memberships []set
@@ -43,481 +98,6 @@ type level struct {
 	communities [][]graph.Node
 }
 
-var communityQTests = []struct {
-	name       string
-	g          []set
-	structures []structure
-
-	wantLevels []level
-}{
-	// The java reference implementation is available from http://www.ludowaltman.nl/slm/.
-	{
-		name: "unconnected",
-		g: []set{
-			/* Nodes 0-4 are implicit .*/ 5: nil,
-		},
-		structures: []structure{
-			{
-				resolution: 1,
-				memberships: []set{
-					0: linksTo(0),
-					1: linksTo(1),
-					2: linksTo(2),
-					3: linksTo(3),
-					4: linksTo(4),
-					5: linksTo(5),
-				},
-				want: math.NaN(),
-			},
-		},
-		wantLevels: []level{
-			{
-				q: math.Inf(-1), // Here math.Inf(-1) is used as a place holder for NaN to allow use of reflect.DeepEqual.
-				communities: [][]graph.Node{
-					{simple.Node(0)},
-					{simple.Node(1)},
-					{simple.Node(2)},
-					{simple.Node(3)},
-					{simple.Node(4)},
-					{simple.Node(5)},
-				},
-			},
-		},
-	},
-	{
-		name: "small_dumbell",
-		g: []set{
-			0: linksTo(1, 2),
-			1: linksTo(2),
-			2: linksTo(3),
-			3: linksTo(4, 5),
-			4: linksTo(5),
-			5: nil,
-		},
-		structures: []structure{
-			{
-				resolution: 1,
-				// community structure and modularity calculated by java reference implementation.
-				memberships: []set{
-					0: linksTo(0, 1, 2),
-					1: linksTo(3, 4, 5),
-				},
-				want: 0.357, tol: 1e-3,
-			},
-			{
-				resolution: 1,
-				memberships: []set{
-					0: linksTo(0, 1, 2, 3, 4, 5),
-				},
-				// theoretical expectation.
-				want: 0, tol: 1e-14,
-			},
-		},
-		wantLevels: []level{
-			{
-				q: 0.35714285714285715,
-				communities: [][]graph.Node{
-					{simple.Node(0), simple.Node(1), simple.Node(2)},
-					{simple.Node(3), simple.Node(4), simple.Node(5)},
-				},
-			},
-			{
-				q: -0.17346938775510204,
-				communities: [][]graph.Node{
-					{simple.Node(0)},
-					{simple.Node(1)},
-					{simple.Node(2)},
-					{simple.Node(3)},
-					{simple.Node(4)},
-					{simple.Node(5)},
-				},
-			},
-		},
-	},
-	{
-		// W. W. Zachary, An information flow model for conflict and fission in small groups,
-		// Journal of Anthropological Research 33, 452-473 (1977).
-		name: "zachary",
-		g: []set{
-			0:  linksTo(1, 2, 3, 4, 5, 6, 7, 8, 10, 11, 12, 13, 17, 19, 21, 31),
-			1:  linksTo(2, 3, 7, 13, 17, 19, 21, 30),
-			2:  linksTo(3, 7, 8, 9, 13, 27, 28, 32),
-			3:  linksTo(7, 12, 13),
-			4:  linksTo(6, 10),
-			5:  linksTo(6, 10, 16),
-			6:  linksTo(16),
-			8:  linksTo(30, 32, 33),
-			9:  linksTo(33),
-			13: linksTo(33),
-			14: linksTo(32, 33),
-			15: linksTo(32, 33),
-			18: linksTo(32, 33),
-			19: linksTo(33),
-			20: linksTo(32, 33),
-			22: linksTo(32, 33),
-			23: linksTo(25, 27, 29, 32, 33),
-			24: linksTo(25, 27, 31),
-			25: linksTo(31),
-			26: linksTo(29, 33),
-			27: linksTo(33),
-			28: linksTo(31, 33),
-			29: linksTo(32, 33),
-			30: linksTo(32, 33),
-			31: linksTo(32, 33),
-			32: linksTo(33),
-			33: nil,
-		},
-		structures: []structure{
-			{
-				resolution: 1,
-				// community structure and modularity from doi: 10.1140/epjb/e2013-40829-0
-				memberships: []set{
-					0: linksTo(0, 1, 2, 3, 7, 11, 12, 13, 17, 19, 21),
-					1: linksTo(4, 5, 6, 10, 16),
-					2: linksTo(8, 9, 14, 15, 18, 20, 22, 26, 29, 30, 32, 33),
-					3: linksTo(23, 24, 25, 27, 28, 31),
-				},
-				// Noted to be the optimal modularisation in the paper above.
-				want: 0.4198, tol: 1e-4,
-			},
-			{
-				resolution: 0.5,
-				// community structure and modularity calculated by java reference implementation.
-				memberships: []set{
-					0: linksTo(0, 1, 2, 3, 4, 5, 6, 7, 9, 10, 11, 12, 13, 16, 17, 19, 21),
-					1: linksTo(8, 14, 15, 18, 20, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33),
-				},
-				want: 0.6218, tol: 1e-3,
-			},
-			{
-				resolution: 2,
-				// community structure and modularity calculated by java reference implementation.
-				memberships: []set{
-					0: linksTo(14, 18, 20, 22, 32, 33, 15),
-					1: linksTo(0, 1, 11, 17, 19, 21),
-					2: linksTo(2, 3, 7, 9, 12, 13),
-					3: linksTo(4, 5, 6, 10, 16),
-					4: linksTo(24, 25, 28, 31),
-					5: linksTo(23, 26, 27, 29),
-					6: linksTo(8, 30),
-				},
-				want: 0.1645, tol: 1e-3,
-			},
-		},
-		wantLevels: []level{
-			{
-				q: 0.4197896120973044,
-				communities: [][]graph.Node{
-					{simple.Node(0), simple.Node(1), simple.Node(2), simple.Node(3), simple.Node(7), simple.Node(11), simple.Node(12), simple.Node(13), simple.Node(17), simple.Node(19), simple.Node(21)},
-					{simple.Node(4), simple.Node(5), simple.Node(6), simple.Node(10), simple.Node(16)},
-					{simple.Node(8), simple.Node(9), simple.Node(14), simple.Node(15), simple.Node(18), simple.Node(20), simple.Node(22), simple.Node(26), simple.Node(29), simple.Node(30), simple.Node(32), simple.Node(33)},
-					{simple.Node(23), simple.Node(24), simple.Node(25), simple.Node(27), simple.Node(28), simple.Node(31)},
-				},
-			},
-			{
-				q: 0.39907955292570674,
-				communities: [][]graph.Node{
-					{simple.Node(0), simple.Node(1), simple.Node(2), simple.Node(3), simple.Node(7), simple.Node(11), simple.Node(12), simple.Node(13), simple.Node(17), simple.Node(19), simple.Node(21)},
-					{simple.Node(4), simple.Node(10)},
-					{simple.Node(5), simple.Node(6), simple.Node(16)},
-					{simple.Node(8), simple.Node(9), simple.Node(14), simple.Node(15), simple.Node(18), simple.Node(20), simple.Node(22), simple.Node(26), simple.Node(29), simple.Node(30), simple.Node(32), simple.Node(33)},
-					{simple.Node(23), simple.Node(24), simple.Node(25), simple.Node(27), simple.Node(28), simple.Node(31)},
-				},
-			},
-			{
-				q: -0.04980276134122286,
-				communities: [][]graph.Node{
-					{simple.Node(0)},
-					{simple.Node(1)},
-					{simple.Node(2)},
-					{simple.Node(3)},
-					{simple.Node(4)},
-					{simple.Node(5)},
-					{simple.Node(6)},
-					{simple.Node(7)},
-					{simple.Node(8)},
-					{simple.Node(9)},
-					{simple.Node(10)},
-					{simple.Node(11)},
-					{simple.Node(12)},
-					{simple.Node(13)},
-					{simple.Node(14)},
-					{simple.Node(15)},
-					{simple.Node(16)},
-					{simple.Node(17)},
-					{simple.Node(18)},
-					{simple.Node(19)},
-					{simple.Node(20)},
-					{simple.Node(21)},
-					{simple.Node(22)},
-					{simple.Node(23)},
-					{simple.Node(24)},
-					{simple.Node(25)},
-					{simple.Node(26)},
-					{simple.Node(27)},
-					{simple.Node(28)},
-					{simple.Node(29)},
-					{simple.Node(30)},
-					{simple.Node(31)},
-					{simple.Node(32)},
-					{simple.Node(33)},
-				},
-			},
-		},
-	},
-	{
-		// doi:10.1088/1742-5468/2008/10/P10008 figure 1
-		name: "blondel",
-		g: []set{
-			0:  linksTo(2, 3, 4, 5),
-			1:  linksTo(2, 4, 7),
-			2:  linksTo(4, 5, 6),
-			3:  linksTo(7),
-			4:  linksTo(10),
-			5:  linksTo(7, 11),
-			6:  linksTo(7, 11),
-			8:  linksTo(9, 10, 11, 14, 15),
-			9:  linksTo(12, 14),
-			10: linksTo(11, 12, 13, 14),
-			11: linksTo(13),
-			15: nil,
-		},
-		structures: []structure{
-			{
-				resolution: 1,
-				// community structure and modularity calculated by java reference implementation.
-				memberships: []set{
-					0: linksTo(0, 1, 2, 3, 4, 5, 6, 7),
-					1: linksTo(8, 9, 10, 11, 12, 13, 14, 15),
-				},
-				want: 0.3922, tol: 1e-4,
-			},
-		},
-		wantLevels: []level{
-			{
-				q: 0.39221938775510207,
-				communities: [][]graph.Node{
-					{simple.Node(0), simple.Node(1), simple.Node(2), simple.Node(3), simple.Node(4), simple.Node(5), simple.Node(6), simple.Node(7)},
-					{simple.Node(8), simple.Node(9), simple.Node(10), simple.Node(11), simple.Node(12), simple.Node(13), simple.Node(14), simple.Node(15)},
-				},
-			},
-			{
-				q: 0.34630102040816324,
-				communities: [][]graph.Node{
-					{simple.Node(0), simple.Node(1), simple.Node(2), simple.Node(4), simple.Node(5)},
-					{simple.Node(3), simple.Node(6), simple.Node(7)},
-					{simple.Node(8), simple.Node(9), simple.Node(10), simple.Node(12), simple.Node(14), simple.Node(15)},
-					{simple.Node(11), simple.Node(13)},
-				},
-			},
-			{
-				q: -0.07142857142857144,
-				communities: [][]graph.Node{
-					{simple.Node(0)},
-					{simple.Node(1)},
-					{simple.Node(2)},
-					{simple.Node(3)},
-					{simple.Node(4)},
-					{simple.Node(5)},
-					{simple.Node(6)},
-					{simple.Node(7)},
-					{simple.Node(8)},
-					{simple.Node(9)},
-					{simple.Node(10)},
-					{simple.Node(11)},
-					{simple.Node(12)},
-					{simple.Node(13)},
-					{simple.Node(14)},
-					{simple.Node(15)},
-				},
-			},
-		},
-	},
-}
-
-func TestCommunityQ(t *testing.T) {
-	for _, test := range communityQTests {
-		g := simple.NewUndirectedGraph(0, 0)
-		for u, e := range test.g {
-			// Add nodes that are not defined by an edge.
-			if !g.Has(simple.Node(u)) {
-				g.AddNode(simple.Node(u))
-			}
-			for v := range e {
-				g.SetEdge(simple.Edge{F: simple.Node(u), T: simple.Node(v), W: 1})
-			}
-		}
-		for _, structure := range test.structures {
-			communities := make([][]graph.Node, len(structure.memberships))
-			for i, c := range structure.memberships {
-				for n := range c {
-					communities[i] = append(communities[i], simple.Node(n))
-				}
-			}
-			got := Q(g, communities, structure.resolution)
-			if !floats.EqualWithinAbsOrRel(got, structure.want, structure.tol, structure.tol) && math.IsNaN(got) != math.IsNaN(structure.want) {
-				for _, c := range communities {
-					sort.Sort(ordered.ByID(c))
-				}
-				t.Errorf("unexpected Q value for %q %v: got: %v want: %v",
-					test.name, communities, got, structure.want)
-			}
-		}
-	}
-}
-
-func TestCommunityDeltaQ(t *testing.T) {
-tests:
-	for _, test := range communityQTests {
-		g := simple.NewUndirectedGraph(0, 0)
-		for u, e := range test.g {
-			// Add nodes that are not defined by an edge.
-			if !g.Has(simple.Node(u)) {
-				g.AddNode(simple.Node(u))
-			}
-			for v := range e {
-				g.SetEdge(simple.Edge{F: simple.Node(u), T: simple.Node(v), W: 1})
-			}
-		}
-
-		rnd := rand.New(rand.NewSource(1)).Intn
-		for _, structure := range test.structures {
-			communityOf := make(map[int]int)
-			communities := make([][]graph.Node, len(structure.memberships))
-			for i, c := range structure.memberships {
-				for n := range c {
-					communityOf[n] = i
-					communities[i] = append(communities[i], simple.Node(n))
-				}
-				sort.Sort(ordered.ByID(communities[i]))
-			}
-
-			before := Q(g, communities, structure.resolution)
-
-			l := newLocalMover(reduce(g, nil), communities, structure.resolution)
-			if l == nil {
-				if !math.IsNaN(before) {
-					t.Errorf("unexpected nil localMover with non-NaN Q graph: Q=%.4v", before)
-				}
-				continue tests
-			}
-
-			// This is done to avoid run-to-run
-			// variation due to map iteration order.
-			sort.Sort(ordered.ByID(l.nodes))
-
-			l.shuffle(rnd)
-
-			for _, target := range l.nodes {
-				got, gotDst, gotSrc := l.deltaQ(target)
-
-				want, wantDst := math.Inf(-1), -1
-				migrated := make([][]graph.Node, len(structure.memberships))
-				for i, c := range structure.memberships {
-					for n := range c {
-						if n == target.ID() {
-							continue
-						}
-						migrated[i] = append(migrated[i], simple.Node(n))
-					}
-					sort.Sort(ordered.ByID(migrated[i]))
-				}
-
-				for i, c := range structure.memberships {
-					if i == communityOf[target.ID()] {
-						continue
-					}
-					connected := false
-					for n := range c {
-						if g.HasEdgeBetween(simple.Node(n), target) {
-							connected = true
-							break
-						}
-					}
-					if !connected {
-						continue
-					}
-					migrated[i] = append(migrated[i], target)
-					after := Q(g, migrated, structure.resolution)
-					migrated[i] = migrated[i][:len(migrated[i])-1]
-					if after-before > want {
-						want = after - before
-						wantDst = i
-					}
-				}
-
-				if !floats.EqualWithinAbsOrRel(got, want, structure.tol, structure.tol) || gotDst != wantDst {
-					t.Errorf("unexpected result moving n=%d in c=%d of %s/%.4v: got: %.4v,%d want: %.4v,%d"+
-						"\n\t%v\n\t%v",
-						target.ID(), communityOf[target.ID()], test.name, structure.resolution, got, gotDst, want, wantDst,
-						communities, migrated)
-				}
-				if gotSrc.community != communityOf[target.ID()] {
-					t.Errorf("unexpected source community index: got: %d want: %d", gotSrc, communityOf[target.ID()])
-				} else if communities[gotSrc.community][gotSrc.node].ID() != target.ID() {
-					wantNodeIdx := -1
-					for i, n := range communities[gotSrc.community] {
-						if n.ID() == target.ID() {
-							wantNodeIdx = i
-							break
-						}
-					}
-					t.Errorf("unexpected source node index: got: %d want: %d", gotSrc.node, wantNodeIdx)
-				}
-			}
-		}
-	}
-}
-
-func TestReduceQConsistency(t *testing.T) {
-tests:
-	for _, test := range communityQTests {
-		g := simple.NewUndirectedGraph(0, 0)
-		for u, e := range test.g {
-			// Add nodes that are not defined by an edge.
-			if !g.Has(simple.Node(u)) {
-				g.AddNode(simple.Node(u))
-			}
-			for v := range e {
-				g.SetEdge(simple.Edge{F: simple.Node(u), T: simple.Node(v), W: 1})
-			}
-		}
-
-		for _, structure := range test.structures {
-			if math.IsNaN(structure.want) {
-				continue tests
-			}
-
-			communities := make([][]graph.Node, len(structure.memberships))
-			for i, c := range structure.memberships {
-				for n := range c {
-					communities[i] = append(communities[i], simple.Node(n))
-				}
-				sort.Sort(ordered.ByID(communities[i]))
-			}
-
-			gQ := Q(g, communities, structure.resolution)
-			gQnull := Q(g, nil, 1)
-
-			cg0 := reduce(g, nil)
-			cg0Qnull := Q(cg0, cg0.Structure(), 1)
-			if !floats.EqualWithinAbsOrRel(gQnull, cg0Qnull, structure.tol, structure.tol) {
-				t.Errorf("disgagreement between null Q from method: %v and function: %v", cg0Qnull, gQnull)
-			}
-			cg0Q := Q(cg0, communities, structure.resolution)
-			if !floats.EqualWithinAbsOrRel(gQ, cg0Q, structure.tol, structure.tol) {
-				t.Errorf("unexpected Q result after initial conversion: got: %v want :%v", gQ, cg0Q)
-			}
-
-			cg1 := reduce(cg0, communities)
-			cg1Q := Q(cg1, cg1.Structure(), structure.resolution)
-			if !floats.EqualWithinAbsOrRel(gQ, cg1Q, structure.tol, structure.tol) {
-				t.Errorf("unexpected Q result after initial condensation: got: %v want :%v", gQ, cg1Q)
-			}
-		}
-	}
-}
-
 type moveStructures struct {
 	memberships []set
 	targetNodes []graph.Node
@@ -526,225 +106,10 @@ type moveStructures struct {
 	tol        float64
 }
 
-var localMoveTests = []struct {
-	name       string
-	g          []set
-	structures []moveStructures
-}{
-	{
-		// doi:10.1088/1742-5468/2008/10/P10008 figure 1
-		name: "blondel",
-		g: []set{
-			0:  linksTo(2, 3, 4, 5),
-			1:  linksTo(2, 4, 7),
-			2:  linksTo(4, 5, 6),
-			3:  linksTo(7),
-			4:  linksTo(10),
-			5:  linksTo(7, 11),
-			6:  linksTo(7, 11),
-			8:  linksTo(9, 10, 11, 14, 15),
-			9:  linksTo(12, 14),
-			10: linksTo(11, 12, 13, 14),
-			11: linksTo(13),
-			15: nil,
-		},
-		structures: []moveStructures{
-			{
-				memberships: []set{
-					0: linksTo(0, 1, 2, 4, 5),
-					1: linksTo(3, 6, 7),
-					2: linksTo(8, 9, 10, 12, 14, 15),
-					3: linksTo(11, 13),
-				},
-				targetNodes: []graph.Node{simple.Node(0)},
-				resolution:  1,
-				tol:         1e-14,
-			},
-			{
-				memberships: []set{
-					0: linksTo(0, 1, 2, 4, 5),
-					1: linksTo(3, 6, 7),
-					2: linksTo(8, 9, 10, 12, 14, 15),
-					3: linksTo(11, 13),
-				},
-				targetNodes: []graph.Node{simple.Node(3)},
-				resolution:  1,
-				tol:         1e-14,
-			},
-			{
-				memberships: []set{
-					0: linksTo(0, 1, 2, 4, 5),
-					1: linksTo(3, 6, 7),
-					2: linksTo(8, 9, 10, 12, 14, 15),
-					3: linksTo(11, 13),
-				},
-				// Case to demonstrate when A_aa != k_a^𝛼.
-				targetNodes: []graph.Node{simple.Node(3), simple.Node(2)},
-				resolution:  1,
-				tol:         1e-14,
-			},
-		},
-	},
-}
-
-func TestMoveLocal(t *testing.T) {
-	for _, test := range localMoveTests {
-		g := simple.NewUndirectedGraph(0, 0)
-		for u, e := range test.g {
-			// Add nodes that are not defined by an edge.
-			if !g.Has(simple.Node(u)) {
-				g.AddNode(simple.Node(u))
-			}
-			for v := range e {
-				g.SetEdge(simple.Edge{F: simple.Node(u), T: simple.Node(v), W: 1})
-			}
-		}
-
-		for _, structure := range test.structures {
-			communities := make([][]graph.Node, len(structure.memberships))
-			for i, c := range structure.memberships {
-				for n := range c {
-					communities[i] = append(communities[i], simple.Node(n))
-				}
-				sort.Sort(ordered.ByID(communities[i]))
-			}
-
-			r := reduce(reduce(g, nil), communities)
-
-			l := newLocalMover(r, r.communities, structure.resolution)
-			for _, n := range structure.targetNodes {
-				dQ, dst, src := l.deltaQ(n)
-				if dQ > 0 {
-					before := Q(r, l.communities, structure.resolution)
-					l.move(dst, src)
-					after := Q(r, l.communities, structure.resolution)
-					want := after - before
-					if !floats.EqualWithinAbsOrRel(dQ, want, structure.tol, structure.tol) {
-						t.Errorf("unexpected deltaQ: got: %v want: %v", dQ, want)
-					}
-				}
-			}
-		}
-	}
-}
-
-func TestLouvain(t *testing.T) {
-	const louvainIterations = 20
-
-	for _, test := range communityQTests {
-		g := simple.NewUndirectedGraph(0, 0)
-		for u, e := range test.g {
-			// Add nodes that are not defined by an edge.
-			if !g.Has(simple.Node(u)) {
-				g.AddNode(simple.Node(u))
-			}
-			for v := range e {
-				g.SetEdge(simple.Edge{F: simple.Node(u), T: simple.Node(v), W: 1})
-			}
-		}
-
-		if test.structures[0].resolution != 1 {
-			panic("bad test: expect resolution=1")
-		}
-		want := make([][]graph.Node, len(test.structures[0].memberships))
-		for i, c := range test.structures[0].memberships {
-			for n := range c {
-				want[i] = append(want[i], simple.Node(n))
-			}
-			sort.Sort(ordered.ByID(want[i]))
-		}
-		sort.Sort(ordered.BySliceIDs(want))
-
-		var (
-			got   *ReducedUndirected
-			bestQ = math.Inf(-1)
-		)
-		// Louvain is randomised so we do this to
-		// ensure the level tests are consistent.
-		src := rand.New(rand.NewSource(1))
-		for i := 0; i < louvainIterations; i++ {
-			r := Louvain(g, 1, src)
-			if q := Q(r, nil, 1); q > bestQ || math.IsNaN(q) {
-				bestQ = q
-				got = r
-
-				if math.IsNaN(q) {
-					// Don't try again for non-connected case.
-					break
-				}
-			}
-
-			var qs []float64
-			for p := r; p != nil; p = p.Expanded() {
-				qs = append(qs, Q(p, nil, 1))
-			}
-
-			// Recovery of Q values is reversed.
-			if reverse(qs); !sort.Float64sAreSorted(qs) {
-				t.Errorf("Q values not monotonically increasing: %.5v", qs)
-			}
-		}
-
-		gotCommunities := got.Communities()
-		for _, c := range gotCommunities {
-			sort.Sort(ordered.ByID(c))
-		}
-		sort.Sort(ordered.BySliceIDs(gotCommunities))
-		if !reflect.DeepEqual(gotCommunities, want) {
-			t.Errorf("unexpected community membership for %s Q=%.4v:\n\tgot: %v\n\twant:%v",
-				test.name, bestQ, gotCommunities, want)
-			continue
-		}
-
-		var levels []level
-		for p := got; p != nil; p = p.Expanded() {
-			var communities [][]graph.Node
-			if p.parent != nil {
-				communities = p.parent.Communities()
-				for _, c := range communities {
-					sort.Sort(ordered.ByID(c))
-				}
-				sort.Sort(ordered.BySliceIDs(communities))
-			} else {
-				communities = reduce(g, nil).Communities()
-			}
-			q := Q(p, nil, 1)
-			if math.IsNaN(q) {
-				// Use an equalable flag value in place of NaN.
-				q = math.Inf(-1)
-			}
-			levels = append(levels, level{q: q, communities: communities})
-		}
-		if !reflect.DeepEqual(levels, test.wantLevels) {
-			t.Errorf("unexpected level structure:\n\tgot: %v\n\twant:%v", levels, test.wantLevels)
-		}
-	}
-}
-
 func reverse(f []float64) {
 	for i, j := 0, len(f)-1; i < j; i, j = i+1, j-1 {
 		f[i], f[j] = f[j], f[i]
 	}
-}
-
-func TestNonContiguous(t *testing.T) {
-	g := simple.NewUndirectedGraph(0, 0)
-	for _, e := range []simple.Edge{
-		{F: simple.Node(0), T: simple.Node(1), W: 1},
-		{F: simple.Node(4), T: simple.Node(5), W: 1},
-	} {
-		g.SetEdge(e)
-	}
-
-	func() {
-		defer func() {
-			r := recover()
-			if r != nil {
-				t.Error("unexpected panic with non-contiguous ID range")
-			}
-		}()
-		Louvain(g, 1, nil)
-	}()
 }
 
 var dupGraph = simple.NewUndirectedGraph(0, 0)
@@ -753,12 +118,5 @@ func init() {
 	err := gen.Duplication(dupGraph, 1000, 0.8, 0.1, 0.5, rand.New(rand.NewSource(1)))
 	if err != nil {
 		panic(err)
-	}
-}
-
-func BenchmarkLouvain(b *testing.B) {
-	src := rand.New(rand.NewSource(1))
-	for i := 0; i < b.N; i++ {
-		Louvain(dupGraph, 1, src)
 	}
 }

--- a/community/louvain_undirected_test.go
+++ b/community/louvain_undirected_test.go
@@ -1,0 +1,648 @@
+// Copyright ©2015 The gonum Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package community
+
+import (
+	"math"
+	"math/rand"
+	"reflect"
+	"sort"
+	"testing"
+
+	"github.com/gonum/floats"
+	"github.com/gonum/graph"
+	"github.com/gonum/graph/internal/ordered"
+	"github.com/gonum/graph/simple"
+)
+
+var communityUndirectedQTests = []struct {
+	name       string
+	g          []set
+	structures []structure
+
+	wantLevels []level
+}{
+	// The java reference implementation is available from http://www.ludowaltman.nl/slm/.
+	{
+		name: "unconnected",
+		g:    unconnected,
+		structures: []structure{
+			{
+				resolution: 1,
+				memberships: []set{
+					0: linksTo(0),
+					1: linksTo(1),
+					2: linksTo(2),
+					3: linksTo(3),
+					4: linksTo(4),
+					5: linksTo(5),
+				},
+				want: math.NaN(),
+			},
+		},
+		wantLevels: []level{
+			{
+				q: math.Inf(-1), // Here math.Inf(-1) is used as a place holder for NaN to allow use of reflect.DeepEqual.
+				communities: [][]graph.Node{
+					{simple.Node(0)},
+					{simple.Node(1)},
+					{simple.Node(2)},
+					{simple.Node(3)},
+					{simple.Node(4)},
+					{simple.Node(5)},
+				},
+			},
+		},
+	},
+	{
+		name: "small_dumbell",
+		g:    smallDumbell,
+		structures: []structure{
+			{
+				resolution: 1,
+				// community structure and modularity calculated by java reference implementation.
+				memberships: []set{
+					0: linksTo(0, 1, 2),
+					1: linksTo(3, 4, 5),
+				},
+				want: 0.357, tol: 1e-3,
+			},
+			{
+				resolution: 1,
+				memberships: []set{
+					0: linksTo(0, 1, 2, 3, 4, 5),
+				},
+				// theoretical expectation.
+				want: 0, tol: 1e-14,
+			},
+		},
+		wantLevels: []level{
+			{
+				q: 0.35714285714285715,
+				communities: [][]graph.Node{
+					{simple.Node(0), simple.Node(1), simple.Node(2)},
+					{simple.Node(3), simple.Node(4), simple.Node(5)},
+				},
+			},
+			{
+				q: -0.17346938775510204,
+				communities: [][]graph.Node{
+					{simple.Node(0)},
+					{simple.Node(1)},
+					{simple.Node(2)},
+					{simple.Node(3)},
+					{simple.Node(4)},
+					{simple.Node(5)},
+				},
+			},
+		},
+	},
+	{
+		name: "zachary",
+		g:    zachary,
+		structures: []structure{
+			{
+				resolution: 1,
+				// community structure and modularity from doi: 10.1140/epjb/e2013-40829-0
+				memberships: []set{
+					0: linksTo(0, 1, 2, 3, 7, 11, 12, 13, 17, 19, 21),
+					1: linksTo(4, 5, 6, 10, 16),
+					2: linksTo(8, 9, 14, 15, 18, 20, 22, 26, 29, 30, 32, 33),
+					3: linksTo(23, 24, 25, 27, 28, 31),
+				},
+				// Noted to be the optimal modularisation in the paper above.
+				want: 0.4198, tol: 1e-4,
+			},
+			{
+				resolution: 0.5,
+				// community structure and modularity calculated by java reference implementation.
+				memberships: []set{
+					0: linksTo(0, 1, 2, 3, 4, 5, 6, 7, 9, 10, 11, 12, 13, 16, 17, 19, 21),
+					1: linksTo(8, 14, 15, 18, 20, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33),
+				},
+				want: 0.6218, tol: 1e-3,
+			},
+			{
+				resolution: 2,
+				// community structure and modularity calculated by java reference implementation.
+				memberships: []set{
+					0: linksTo(14, 18, 20, 22, 32, 33, 15),
+					1: linksTo(0, 1, 11, 17, 19, 21),
+					2: linksTo(2, 3, 7, 9, 12, 13),
+					3: linksTo(4, 5, 6, 10, 16),
+					4: linksTo(24, 25, 28, 31),
+					5: linksTo(23, 26, 27, 29),
+					6: linksTo(8, 30),
+				},
+				want: 0.1645, tol: 1e-3,
+			},
+		},
+		wantLevels: []level{
+			{
+				q: 0.4197896120973044,
+				communities: [][]graph.Node{
+					{simple.Node(0), simple.Node(1), simple.Node(2), simple.Node(3), simple.Node(7), simple.Node(11), simple.Node(12), simple.Node(13), simple.Node(17), simple.Node(19), simple.Node(21)},
+					{simple.Node(4), simple.Node(5), simple.Node(6), simple.Node(10), simple.Node(16)},
+					{simple.Node(8), simple.Node(9), simple.Node(14), simple.Node(15), simple.Node(18), simple.Node(20), simple.Node(22), simple.Node(26), simple.Node(29), simple.Node(30), simple.Node(32), simple.Node(33)},
+					{simple.Node(23), simple.Node(24), simple.Node(25), simple.Node(27), simple.Node(28), simple.Node(31)},
+				},
+			},
+			{
+				q: 0.39907955292570674,
+				communities: [][]graph.Node{
+					{simple.Node(0), simple.Node(1), simple.Node(2), simple.Node(3), simple.Node(7), simple.Node(11), simple.Node(12), simple.Node(13), simple.Node(17), simple.Node(19), simple.Node(21)},
+					{simple.Node(4), simple.Node(10)},
+					{simple.Node(5), simple.Node(6), simple.Node(16)},
+					{simple.Node(8), simple.Node(9), simple.Node(14), simple.Node(15), simple.Node(18), simple.Node(20), simple.Node(22), simple.Node(26), simple.Node(29), simple.Node(30), simple.Node(32), simple.Node(33)},
+					{simple.Node(23), simple.Node(24), simple.Node(25), simple.Node(27), simple.Node(28), simple.Node(31)},
+				},
+			},
+			{
+				q: -0.04980276134122286,
+				communities: [][]graph.Node{
+					{simple.Node(0)},
+					{simple.Node(1)},
+					{simple.Node(2)},
+					{simple.Node(3)},
+					{simple.Node(4)},
+					{simple.Node(5)},
+					{simple.Node(6)},
+					{simple.Node(7)},
+					{simple.Node(8)},
+					{simple.Node(9)},
+					{simple.Node(10)},
+					{simple.Node(11)},
+					{simple.Node(12)},
+					{simple.Node(13)},
+					{simple.Node(14)},
+					{simple.Node(15)},
+					{simple.Node(16)},
+					{simple.Node(17)},
+					{simple.Node(18)},
+					{simple.Node(19)},
+					{simple.Node(20)},
+					{simple.Node(21)},
+					{simple.Node(22)},
+					{simple.Node(23)},
+					{simple.Node(24)},
+					{simple.Node(25)},
+					{simple.Node(26)},
+					{simple.Node(27)},
+					{simple.Node(28)},
+					{simple.Node(29)},
+					{simple.Node(30)},
+					{simple.Node(31)},
+					{simple.Node(32)},
+					{simple.Node(33)},
+				},
+			},
+		},
+	},
+	{
+		name: "blondel",
+		g:    blondel,
+		structures: []structure{
+			{
+				resolution: 1,
+				// community structure and modularity calculated by java reference implementation.
+				memberships: []set{
+					0: linksTo(0, 1, 2, 3, 4, 5, 6, 7),
+					1: linksTo(8, 9, 10, 11, 12, 13, 14, 15),
+				},
+				want: 0.3922, tol: 1e-4,
+			},
+		},
+		wantLevels: []level{
+			{
+				q: 0.39221938775510207,
+				communities: [][]graph.Node{
+					{simple.Node(0), simple.Node(1), simple.Node(2), simple.Node(3), simple.Node(4), simple.Node(5), simple.Node(6), simple.Node(7)},
+					{simple.Node(8), simple.Node(9), simple.Node(10), simple.Node(11), simple.Node(12), simple.Node(13), simple.Node(14), simple.Node(15)},
+				},
+			},
+			{
+				q: 0.34630102040816324,
+				communities: [][]graph.Node{
+					{simple.Node(0), simple.Node(1), simple.Node(2), simple.Node(4), simple.Node(5)},
+					{simple.Node(3), simple.Node(6), simple.Node(7)},
+					{simple.Node(8), simple.Node(9), simple.Node(10), simple.Node(12), simple.Node(14), simple.Node(15)},
+					{simple.Node(11), simple.Node(13)},
+				},
+			},
+			{
+				q: -0.07142857142857144,
+				communities: [][]graph.Node{
+					{simple.Node(0)},
+					{simple.Node(1)},
+					{simple.Node(2)},
+					{simple.Node(3)},
+					{simple.Node(4)},
+					{simple.Node(5)},
+					{simple.Node(6)},
+					{simple.Node(7)},
+					{simple.Node(8)},
+					{simple.Node(9)},
+					{simple.Node(10)},
+					{simple.Node(11)},
+					{simple.Node(12)},
+					{simple.Node(13)},
+					{simple.Node(14)},
+					{simple.Node(15)},
+				},
+			},
+		},
+	},
+}
+
+func TestCommunityQUndirected(t *testing.T) {
+	for _, test := range communityUndirectedQTests {
+		g := simple.NewUndirectedGraph(0, 0)
+		for u, e := range test.g {
+			// Add nodes that are not defined by an edge.
+			if !g.Has(simple.Node(u)) {
+				g.AddNode(simple.Node(u))
+			}
+			for v := range e {
+				g.SetEdge(simple.Edge{F: simple.Node(u), T: simple.Node(v), W: 1})
+			}
+		}
+		for _, structure := range test.structures {
+			communities := make([][]graph.Node, len(structure.memberships))
+			for i, c := range structure.memberships {
+				for n := range c {
+					communities[i] = append(communities[i], simple.Node(n))
+				}
+			}
+			got := Q(g, communities, structure.resolution)
+			if !floats.EqualWithinAbsOrRel(got, structure.want, structure.tol, structure.tol) && math.IsNaN(got) != math.IsNaN(structure.want) {
+				for _, c := range communities {
+					sort.Sort(ordered.ByID(c))
+				}
+				t.Errorf("unexpected Q value for %q %v: got: %v want: %v",
+					test.name, communities, got, structure.want)
+			}
+		}
+	}
+}
+
+func TestCommunityDeltaQUndirected(t *testing.T) {
+tests:
+	for _, test := range communityUndirectedQTests {
+		g := simple.NewUndirectedGraph(0, 0)
+		for u, e := range test.g {
+			// Add nodes that are not defined by an edge.
+			if !g.Has(simple.Node(u)) {
+				g.AddNode(simple.Node(u))
+			}
+			for v := range e {
+				g.SetEdge(simple.Edge{F: simple.Node(u), T: simple.Node(v), W: 1})
+			}
+		}
+
+		rnd := rand.New(rand.NewSource(1)).Intn
+		for _, structure := range test.structures {
+			communityOf := make(map[int]int)
+			communities := make([][]graph.Node, len(structure.memberships))
+			for i, c := range structure.memberships {
+				for n := range c {
+					communityOf[n] = i
+					communities[i] = append(communities[i], simple.Node(n))
+				}
+				sort.Sort(ordered.ByID(communities[i]))
+			}
+
+			before := Q(g, communities, structure.resolution)
+
+			l := newUndirectedLocalMover(reduceUndirected(g, nil), communities, structure.resolution)
+			if l == nil {
+				if !math.IsNaN(before) {
+					t.Errorf("unexpected nil localMover with non-NaN Q graph: Q=%.4v", before)
+				}
+				continue tests
+			}
+
+			// This is done to avoid run-to-run
+			// variation due to map iteration order.
+			sort.Sort(ordered.ByID(l.nodes))
+
+			l.shuffle(rnd)
+
+			for _, target := range l.nodes {
+				got, gotDst, gotSrc := l.deltaQ(target)
+
+				want, wantDst := math.Inf(-1), -1
+				migrated := make([][]graph.Node, len(structure.memberships))
+				for i, c := range structure.memberships {
+					for n := range c {
+						if n == target.ID() {
+							continue
+						}
+						migrated[i] = append(migrated[i], simple.Node(n))
+					}
+					sort.Sort(ordered.ByID(migrated[i]))
+				}
+
+				for i, c := range structure.memberships {
+					if i == communityOf[target.ID()] {
+						continue
+					}
+					connected := false
+					for n := range c {
+						if g.HasEdgeBetween(simple.Node(n), target) {
+							connected = true
+							break
+						}
+					}
+					if !connected {
+						continue
+					}
+					migrated[i] = append(migrated[i], target)
+					after := Q(g, migrated, structure.resolution)
+					migrated[i] = migrated[i][:len(migrated[i])-1]
+					if after-before > want {
+						want = after - before
+						wantDst = i
+					}
+				}
+
+				if !floats.EqualWithinAbsOrRel(got, want, structure.tol, structure.tol) || gotDst != wantDst {
+					t.Errorf("unexpected result moving n=%d in c=%d of %s/%.4v: got: %.4v,%d want: %.4v,%d"+
+						"\n\t%v\n\t%v",
+						target.ID(), communityOf[target.ID()], test.name, structure.resolution, got, gotDst, want, wantDst,
+						communities, migrated)
+				}
+				if gotSrc.community != communityOf[target.ID()] {
+					t.Errorf("unexpected source community index: got: %d want: %d", gotSrc, communityOf[target.ID()])
+				} else if communities[gotSrc.community][gotSrc.node].ID() != target.ID() {
+					wantNodeIdx := -1
+					for i, n := range communities[gotSrc.community] {
+						if n.ID() == target.ID() {
+							wantNodeIdx = i
+							break
+						}
+					}
+					t.Errorf("unexpected source node index: got: %d want: %d", gotSrc.node, wantNodeIdx)
+				}
+			}
+		}
+	}
+}
+
+func TestReduceQConsistencyUndirected(t *testing.T) {
+tests:
+	for _, test := range communityUndirectedQTests {
+		g := simple.NewUndirectedGraph(0, 0)
+		for u, e := range test.g {
+			// Add nodes that are not defined by an edge.
+			if !g.Has(simple.Node(u)) {
+				g.AddNode(simple.Node(u))
+			}
+			for v := range e {
+				g.SetEdge(simple.Edge{F: simple.Node(u), T: simple.Node(v), W: 1})
+			}
+		}
+
+		for _, structure := range test.structures {
+			if math.IsNaN(structure.want) {
+				continue tests
+			}
+
+			communities := make([][]graph.Node, len(structure.memberships))
+			for i, c := range structure.memberships {
+				for n := range c {
+					communities[i] = append(communities[i], simple.Node(n))
+				}
+				sort.Sort(ordered.ByID(communities[i]))
+			}
+
+			gQ := Q(g, communities, structure.resolution)
+			gQnull := Q(g, nil, 1)
+
+			cg0 := reduceUndirected(g, nil)
+			cg0Qnull := Q(cg0, cg0.Structure(), 1)
+			if !floats.EqualWithinAbsOrRel(gQnull, cg0Qnull, structure.tol, structure.tol) {
+				t.Errorf("disgagreement between null Q from method: %v and function: %v", cg0Qnull, gQnull)
+			}
+			cg0Q := Q(cg0, communities, structure.resolution)
+			if !floats.EqualWithinAbsOrRel(gQ, cg0Q, structure.tol, structure.tol) {
+				t.Errorf("unexpected Q result after initial conversion: got: %v want :%v", gQ, cg0Q)
+			}
+
+			cg1 := reduceUndirected(cg0, communities)
+			cg1Q := Q(cg1, cg1.Structure(), structure.resolution)
+			if !floats.EqualWithinAbsOrRel(gQ, cg1Q, structure.tol, structure.tol) {
+				t.Errorf("unexpected Q result after initial condensation: got: %v want :%v", gQ, cg1Q)
+			}
+		}
+	}
+}
+
+var localUndirectedMoveTests = []struct {
+	name       string
+	g          []set
+	structures []moveStructures
+}{
+	{
+		name: "blondel",
+		g:    blondel,
+		structures: []moveStructures{
+			{
+				memberships: []set{
+					0: linksTo(0, 1, 2, 4, 5),
+					1: linksTo(3, 6, 7),
+					2: linksTo(8, 9, 10, 12, 14, 15),
+					3: linksTo(11, 13),
+				},
+				targetNodes: []graph.Node{simple.Node(0)},
+				resolution:  1,
+				tol:         1e-14,
+			},
+			{
+				memberships: []set{
+					0: linksTo(0, 1, 2, 4, 5),
+					1: linksTo(3, 6, 7),
+					2: linksTo(8, 9, 10, 12, 14, 15),
+					3: linksTo(11, 13),
+				},
+				targetNodes: []graph.Node{simple.Node(3)},
+				resolution:  1,
+				tol:         1e-14,
+			},
+			{
+				memberships: []set{
+					0: linksTo(0, 1, 2, 4, 5),
+					1: linksTo(3, 6, 7),
+					2: linksTo(8, 9, 10, 12, 14, 15),
+					3: linksTo(11, 13),
+				},
+				// Case to demonstrate when A_aa != k_a^𝛼.
+				targetNodes: []graph.Node{simple.Node(3), simple.Node(2)},
+				resolution:  1,
+				tol:         1e-14,
+			},
+		},
+	},
+}
+
+func TestMoveLocalUndirected(t *testing.T) {
+	for _, test := range localUndirectedMoveTests {
+		g := simple.NewUndirectedGraph(0, 0)
+		for u, e := range test.g {
+			// Add nodes that are not defined by an edge.
+			if !g.Has(simple.Node(u)) {
+				g.AddNode(simple.Node(u))
+			}
+			for v := range e {
+				g.SetEdge(simple.Edge{F: simple.Node(u), T: simple.Node(v), W: 1})
+			}
+		}
+
+		for _, structure := range test.structures {
+			communities := make([][]graph.Node, len(structure.memberships))
+			for i, c := range structure.memberships {
+				for n := range c {
+					communities[i] = append(communities[i], simple.Node(n))
+				}
+				sort.Sort(ordered.ByID(communities[i]))
+			}
+
+			r := reduceUndirected(reduceUndirected(g, nil), communities)
+
+			l := newUndirectedLocalMover(r, r.communities, structure.resolution)
+			for _, n := range structure.targetNodes {
+				dQ, dst, src := l.deltaQ(n)
+				if dQ > 0 {
+					before := Q(r, l.communities, structure.resolution)
+					l.move(dst, src)
+					after := Q(r, l.communities, structure.resolution)
+					want := after - before
+					if !floats.EqualWithinAbsOrRel(dQ, want, structure.tol, structure.tol) {
+						t.Errorf("unexpected deltaQ: got: %v want: %v", dQ, want)
+					}
+				}
+			}
+		}
+	}
+}
+
+func TestLouvain(t *testing.T) {
+	const louvainIterations = 20
+
+	for _, test := range communityUndirectedQTests {
+		g := simple.NewUndirectedGraph(0, 0)
+		for u, e := range test.g {
+			// Add nodes that are not defined by an edge.
+			if !g.Has(simple.Node(u)) {
+				g.AddNode(simple.Node(u))
+			}
+			for v := range e {
+				g.SetEdge(simple.Edge{F: simple.Node(u), T: simple.Node(v), W: 1})
+			}
+		}
+
+		if test.structures[0].resolution != 1 {
+			panic("bad test: expect resolution=1")
+		}
+		want := make([][]graph.Node, len(test.structures[0].memberships))
+		for i, c := range test.structures[0].memberships {
+			for n := range c {
+				want[i] = append(want[i], simple.Node(n))
+			}
+			sort.Sort(ordered.ByID(want[i]))
+		}
+		sort.Sort(ordered.BySliceIDs(want))
+
+		var (
+			got   *ReducedUndirected
+			bestQ = math.Inf(-1)
+		)
+		// Louvain is randomised so we do this to
+		// ensure the level tests are consistent.
+		src := rand.New(rand.NewSource(1))
+		for i := 0; i < louvainIterations; i++ {
+			r := Louvain(g, 1, src)
+			if q := Q(r, nil, 1); q > bestQ || math.IsNaN(q) {
+				bestQ = q
+				got = r
+
+				if math.IsNaN(q) {
+					// Don't try again for non-connected case.
+					break
+				}
+			}
+
+			var qs []float64
+			for p := r; p != nil; p = p.Expanded() {
+				qs = append(qs, Q(p, nil, 1))
+			}
+
+			// Recovery of Q values is reversed.
+			if reverse(qs); !sort.Float64sAreSorted(qs) {
+				t.Errorf("Q values not monotonically increasing: %.5v", qs)
+			}
+		}
+
+		gotCommunities := got.Communities()
+		for _, c := range gotCommunities {
+			sort.Sort(ordered.ByID(c))
+		}
+		sort.Sort(ordered.BySliceIDs(gotCommunities))
+		if !reflect.DeepEqual(gotCommunities, want) {
+			t.Errorf("unexpected community membership for %s Q=%.4v:\n\tgot: %v\n\twant:%v",
+				test.name, bestQ, gotCommunities, want)
+			continue
+		}
+
+		var levels []level
+		for p := got; p != nil; p = p.Expanded() {
+			var communities [][]graph.Node
+			if p.parent != nil {
+				communities = p.parent.Communities()
+				for _, c := range communities {
+					sort.Sort(ordered.ByID(c))
+				}
+				sort.Sort(ordered.BySliceIDs(communities))
+			} else {
+				communities = reduceUndirected(g, nil).Communities()
+			}
+			q := Q(p, nil, 1)
+			if math.IsNaN(q) {
+				// Use an equalable flag value in place of NaN.
+				q = math.Inf(-1)
+			}
+			levels = append(levels, level{q: q, communities: communities})
+		}
+		if !reflect.DeepEqual(levels, test.wantLevels) {
+			t.Errorf("unexpected level structure:\n\tgot: %v\n\twant:%v", levels, test.wantLevels)
+		}
+	}
+}
+
+func TestNonContiguousUndirected(t *testing.T) {
+	g := simple.NewUndirectedGraph(0, 0)
+	for _, e := range []simple.Edge{
+		{F: simple.Node(0), T: simple.Node(1), W: 1},
+		{F: simple.Node(4), T: simple.Node(5), W: 1},
+	} {
+		g.SetEdge(e)
+	}
+
+	func() {
+		defer func() {
+			r := recover()
+			if r != nil {
+				t.Error("unexpected panic with non-contiguous ID range")
+			}
+		}()
+		Louvain(g, 1, nil)
+	}()
+}
+
+func BenchmarkLouvain(b *testing.B) {
+	src := rand.New(rand.NewSource(1))
+	for i := 0; i < b.N; i++ {
+		Louvain(dupGraph, 1, src)
+	}
+}

--- a/community/printgraphs.go
+++ b/community/printgraphs.go
@@ -1,0 +1,142 @@
+// Copyright ©2016 The gonum Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// +build ignore
+
+// printgraphs allows us to generate a consistent directed view of
+// a set of edges that follows a reasonably real-world-meaningful
+// graph. The interpretation of the links in the resulting directed
+// graphs are either "suggests" in the context of a Page Ranking or
+// possibly "looks up to" in the Zachary graph.
+package main
+
+import (
+	"fmt"
+	"sort"
+
+	"github.com/gonum/graph"
+	"github.com/gonum/graph/internal/ordered"
+	"github.com/gonum/graph/network"
+	"github.com/gonum/graph/simple"
+)
+
+// set is an integer set.
+type set map[int]struct{}
+
+func linksTo(i ...int) set {
+	if len(i) == 0 {
+		return nil
+	}
+	s := make(set)
+	for _, v := range i {
+		s[v] = struct{}{}
+	}
+	return s
+}
+
+var (
+	zachary = []set{
+		0:  linksTo(1, 2, 3, 4, 5, 6, 7, 8, 10, 11, 12, 13, 17, 19, 21, 31),
+		1:  linksTo(2, 3, 7, 13, 17, 19, 21, 30),
+		2:  linksTo(3, 7, 8, 9, 13, 27, 28, 32),
+		3:  linksTo(7, 12, 13),
+		4:  linksTo(6, 10),
+		5:  linksTo(6, 10, 16),
+		6:  linksTo(16),
+		8:  linksTo(30, 32, 33),
+		9:  linksTo(33),
+		13: linksTo(33),
+		14: linksTo(32, 33),
+		15: linksTo(32, 33),
+		18: linksTo(32, 33),
+		19: linksTo(33),
+		20: linksTo(32, 33),
+		22: linksTo(32, 33),
+		23: linksTo(25, 27, 29, 32, 33),
+		24: linksTo(25, 27, 31),
+		25: linksTo(31),
+		26: linksTo(29, 33),
+		27: linksTo(33),
+		28: linksTo(31, 33),
+		29: linksTo(32, 33),
+		30: linksTo(32, 33),
+		31: linksTo(32, 33),
+		32: linksTo(33),
+		33: nil,
+	}
+
+	blondel = []set{
+		0:  linksTo(2, 3, 4, 5),
+		1:  linksTo(2, 4, 7),
+		2:  linksTo(4, 5, 6),
+		3:  linksTo(7),
+		4:  linksTo(10),
+		5:  linksTo(7, 11),
+		6:  linksTo(7, 11),
+		8:  linksTo(9, 10, 11, 14, 15),
+		9:  linksTo(12, 14),
+		10: linksTo(11, 12, 13, 14),
+		11: linksTo(13),
+		15: nil,
+	}
+)
+
+func main() {
+	for _, raw := range []struct {
+		name string
+		set  []set
+	}{
+		{"zachary", zachary},
+		{"blondel", blondel},
+	} {
+		g := simple.NewUndirectedGraph(0, 0)
+		for u, e := range raw.set {
+			// Add nodes that are not defined by an edge.
+			if !g.Has(simple.Node(u)) {
+				g.AddNode(simple.Node(u))
+			}
+			for v := range e {
+				g.SetEdge(simple.Edge{F: simple.Node(u), T: simple.Node(v), W: 1})
+			}
+		}
+
+		nodes := g.Nodes()
+		sort.Sort(ordered.ByID(nodes))
+
+		fmt.Printf("%s = []set{\n", raw.name)
+		rank := network.PageRank(asDirected{g}, 0.85, 1e-8)
+		for _, u := range nodes {
+			to := g.From(nodes[u.ID()])
+			sort.Sort(ordered.ByID(to))
+			var links []int
+			for _, v := range to {
+				if rank[u.ID()] <= rank[v.ID()] {
+					links = append(links, v.ID())
+				}
+			}
+
+			if links == nil {
+				fmt.Printf("\t%d: nil, // rank=%.4v\n", u.ID(), rank[u.ID()])
+				continue
+			}
+
+			fmt.Printf("\t%d: linksTo(", u.ID())
+			for i, v := range links {
+				if i != 0 {
+					fmt.Print(", ")
+				}
+				fmt.Print(v)
+			}
+			fmt.Printf("), // rank=%.4v\n", rank[u.ID()])
+		}
+		fmt.Println("}")
+	}
+}
+
+type asDirected struct{ *simple.UndirectedGraph }
+
+func (g asDirected) HasEdgeFromTo(u, v graph.Node) bool {
+	return g.UndirectedGraph.HasEdgeBetween(u, v)
+}
+func (g asDirected) To(v graph.Node) []graph.Node { return g.From(v) }


### PR DESCRIPTION
Please take a look at this for glaring errors (most appropriate way would be to `diff -u louvain_undirected.go louvain_directed.go` (possibly with colour magic) to see the changes in the implementation between the two. These changes should reflect the differences in the louvain.tex for the two approaches, Q and Q^(3).

In writing the changes, I found some things in the louvain.text that I am unsure of (recalling discussions with Vincent Traag and reading his code which does handle this case). Notably, I think that m should not be scaled by 2 in the directed case. Lyron is aware of this and will look into when he is back.

Tests need to be added when I have a clue about what they might actually look like.

Please take a look @Armadilloa16, @vladimir-ch.