### PR TITLE
internal: Add Reset method to NodeStack

### DIFF
--- a/internal/linear/linear.go
+++ b/internal/linear/linear.go
@@ -27,6 +27,9 @@ func (s *NodeStack) Pop() graph.Node {
 // Push adds the node n to the stack at the last position.
 func (s *NodeStack) Push(n graph.Node) { *s = append(*s, n) }
 
+// Reset clears the stack for reuse.
+func (s *NodeStack) Reset() { (*s) = (*s)[:0] }
+
 // NodeQueue implements a FIFO queue.
 type NodeQueue struct {
 	head int

--- a/traverse/traverse.go
+++ b/traverse/traverse.go
@@ -179,7 +179,7 @@ func (d *DepthFirst) Visited(n graph.Node) bool {
 
 // Reset resets the state of the traverser for reuse.
 func (d *DepthFirst) Reset() {
-	d.stack = d.stack[:0]
+	d.stack.Reset()
 	if d.visited != nil {
 		d.visited.Clear()
 	}


### PR DESCRIPTION
When doing breadth first traversal the NodeStack is reset by doing a direct
slice re-size on the underlying data structure (slice) used to implement
the stack. This violates the stack abstraction provided by NodeStack.
Instead of directly re-sizing the slice we can add a method to NodeStack to
reset the underlying data structure.

This patch adds Reset() method to NodeStack. This allows the stack to be
reset while maintaining data abstraction.