### PR TITLE
path: introduce an optimisation for function DijkstraFrom (proposal)

### DIFF
--- a/path/dijkstra.go
+++ b/path/dijkstra.go
@@ -33,6 +33,11 @@ func DijkstraFrom(u graph.Node, g graph.Graph) Shortest {
 	// described in Function B.2 in figure 6 of UTCS Technical
 	// Report TR-07-54.
 	//
+	// This implementation deviates from the report as follows:
+	// - the value of path.dist for the start vertex u is initialized to 0;
+	// - outdated elements from the priority queue (i.e. with respect to the dist value)
+	//   are skipped.
+	//
 	// http://www.cs.utexas.edu/ftp/techreports/tr07-54.pdf
 	Q := priorityQueue{{node: u, dist: 0}}
 	for Q.Len() != 0 {

--- a/path/dijkstra.go
+++ b/path/dijkstra.go
@@ -38,8 +38,8 @@ func DijkstraFrom(u graph.Node, g graph.Graph) Shortest {
 	for Q.Len() != 0 {
 		mid := heap.Pop(&Q).(distanceNode)
 		k := path.indexOf[mid.node.ID()]
-		if mid.dist < path.dist[k] {
-			path.dist[k] = mid.dist
+		if mid.dist > path.dist[k] {
+			continue
 		}
 		for _, v := range g.From(mid.node) {
 			j := path.indexOf[v.ID()]


### PR DESCRIPTION
This commit is a first proposal to reduce unnecessary work due to the use of duplicated nodes in the priority queue. Better alternatives could be discussed. What do you think about this ?

If the distance is greater than the value stored in this distance node, then there already exist a better path to reach this node k. Indeed, the priority queue might contain several distanceNode for the same node k (each time it is updated), because this version of the Dijkstra algorithm does not use a decrease-key operation. Therefore, these distanceNodes should be discarded. Otherwise, the adjacent vertices of k could be traversed more than once in the for loop.