### PR TITLE
all: add deprecation notices to show up in godoc.org

### DIFF
--- a/community/louvain_common.go
+++ b/community/louvain_common.go
@@ -2,6 +2,9 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
+// This repository is no longer maintained.
+// Development has moved to https://github.com/gonum/gonum.
+//
 // Package community provides graph community detection functions.
 package community
 

--- a/doc.go
+++ b/doc.go
@@ -3,6 +3,9 @@
 // license that can be found in the LICENSE file.
 
 /*
+This repository is no longer maintained.
+Development has moved to https://github.com/gonum/gonum.
+
 Package graph implements functions and interfaces to deal with formal discrete graphs. It aims to
 be first and foremost flexible, with speed as a strong second priority.
 

--- a/encoding/dot/dot.go
+++ b/encoding/dot/dot.go
@@ -2,6 +2,9 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
+// This repository is no longer maintained.
+// Development has moved to https://github.com/gonum/gonum.
+//
 // Package dot implements GraphViz DOT marshaling of graphs.
 //
 // See the GraphViz DOT Guide and the DOT grammar for more information

--- a/ex/fdpclust/main.go
+++ b/ex/fdpclust/main.go
@@ -1,3 +1,6 @@
+// This repository is no longer maintained.
+// Development has moved to https://github.com/gonum/gonum.
+//
 package main
 
 import (

--- a/formats/dot/ast/ast.go
+++ b/formats/dot/ast/ast.go
@@ -8,6 +8,9 @@
 // This file is made available under a Creative Commons CC0 1.0
 // Universal Public Domain Dedication.
 
+// This repository is no longer maintained.
+// Development has moved to https://github.com/gonum/gonum.
+//
 // Package ast declares the types used to represent abstract syntax trees of
 // Graphviz DOT graphs.
 package ast

--- a/formats/dot/dot.go
+++ b/formats/dot/dot.go
@@ -8,6 +8,9 @@
 // This file is made available under a Creative Commons CC0 1.0
 // Universal Public Domain Dedication.
 
+// This repository is no longer maintained.
+// Development has moved to https://github.com/gonum/gonum.
+//
 // Package dot implements a parser for Graphviz DOT files.
 package dot
 

--- a/formats/dot/internal/astx/astx.go
+++ b/formats/dot/internal/astx/astx.go
@@ -8,6 +8,9 @@
 // This file is made available under a Creative Commons CC0 1.0
 // Universal Public Domain Dedication.
 
+// This repository is no longer maintained.
+// Development has moved to https://github.com/gonum/gonum.
+//
 // Package astx implements utility functions for generating abstract syntax
 // trees of Graphviz DOT graphs.
 package astx

--- a/graphs/gen/gen.go
+++ b/graphs/gen/gen.go
@@ -2,6 +2,9 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
+// This repository is no longer maintained.
+// Development has moved to https://github.com/gonum/gonum.
+//
 // Package gen provides random graph generation functions.
 package gen
 

--- a/internal/linear/linear.go
+++ b/internal/linear/linear.go
@@ -2,6 +2,9 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
+// This repository is no longer maintained.
+// Development has moved to https://github.com/gonum/gonum.
+//
 // Package linear provides common linear data structures.
 package linear
 

--- a/internal/ordered/sort.go
+++ b/internal/ordered/sort.go
@@ -2,6 +2,9 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
+// This repository is no longer maintained.
+// Development has moved to https://github.com/gonum/gonum.
+//
 // Package ordered provides common sort ordering types.
 package ordered
 

--- a/internal/set/set.go
+++ b/internal/set/set.go
@@ -2,6 +2,9 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
+// This repository is no longer maintained.
+// Development has moved to https://github.com/gonum/gonum.
+//
 // Package set provides integer and graph.Node sets.
 package set
 

--- a/network/network.go
+++ b/network/network.go
@@ -10,5 +10,8 @@
 //    http://www.vldb.org/pvldb/vol7/p1023-maehara.pdf
 // * other centrality measures
 
+// This repository is no longer maintained.
+// Development has moved to https://github.com/gonum/gonum.
+//
 // Package network provides network analysis functions.
 package network

--- a/path/doc.go
+++ b/path/doc.go
@@ -2,5 +2,8 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
+// This repository is no longer maintained.
+// Development has moved to https://github.com/gonum/gonum.
+//
 // Package path provides graph path finding functions.
 package path

--- a/path/dynamic/doc.go
+++ b/path/dynamic/doc.go
@@ -2,5 +2,8 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
+// This repository is no longer maintained.
+// Development has moved to https://github.com/gonum/gonum.
+//
 // Package dynamic provides incremental heuristic graph path finding functions.
 package dynamic

--- a/path/internal/grid.go
+++ b/path/internal/grid.go
@@ -2,6 +2,9 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
+// This repository is no longer maintained.
+// Development has moved to https://github.com/gonum/gonum.
+//
 package internal
 
 import (

--- a/simple/simple.go
+++ b/simple/simple.go
@@ -2,6 +2,9 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
+// This repository is no longer maintained.
+// Development has moved to https://github.com/gonum/gonum.
+//
 // Package simple provides a suite of simple graph implementations satisfying
 // the gonum/graph interfaces.
 package simple

--- a/topo/topo.go
+++ b/topo/topo.go
@@ -2,6 +2,9 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
+// This repository is no longer maintained.
+// Development has moved to https://github.com/gonum/gonum.
+//
 // Package topo provides graph topology analysis functions.
 package topo
 

--- a/traverse/traverse.go
+++ b/traverse/traverse.go
@@ -2,6 +2,9 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
+// This repository is no longer maintained.
+// Development has moved to https://github.com/gonum/gonum.
+//
 // Package traverse provides basic graph traversal primitives.
 package traverse
 


### PR DESCRIPTION
I noticed the package docs were still showing up on godoc in a search for Gonum. This will hopefully prevent people using them accidentally.